### PR TITLE
feat: add drop sets

### DIFF
--- a/app/(app)/(create-plan)/sets-overview.tsx
+++ b/app/(app)/(create-plan)/sets-overview.tsx
@@ -71,6 +71,7 @@ export default function SetsOverviewScreen() {
               <ThemedText style={styles.setTitle}>Set {index + 1}</ThemedText>
               <ThemedText style={styles.setInfo}>
                 {item.isWarmup ? "Warm-up, " : ""}
+                {item.isDropSet ? "Drop set, " : ""}
                 {trackingType === "time"
                   ? item.time
                     ? `${item.time} Seconds, `

--- a/app/(app)/(workout)/workout-session.tsx
+++ b/app/(app)/(workout)/workout-session.tsx
@@ -461,11 +461,19 @@ export default function WorkoutSessionScreen() {
       const currentSetValues =
         weightAndReps[currentExerciseIndex]?.[currentSetIndex] || {};
 
+      const { isWarmup, isDropSet } =
+        workout.exercises[currentExerciseIndex].sets[currentSetIndex];
+
+      const isNextDropSet =
+        workout.exercises[currentExerciseIndex].sets[tempNextSetIndex]
+          .isDropSet;
+
       const nextSetValues = {
         weight:
-          currentSetValues.weight ||
-          previousWorkoutNextSetData?.weight?.toString() ||
-          "",
+          (isWarmup || isDropSet || isNextDropSet) &&
+          previousWorkoutNextSetData?.weight
+            ? previousWorkoutNextSetData?.weight?.toString()
+            : currentSetValues.weight || "",
         reps: previousWorkoutNextSetData?.reps?.toString() || "",
         time: previousWorkoutNextSetData?.time?.toString() || "",
       };

--- a/app/(app)/(workout)/workout-session.tsx
+++ b/app/(app)/(workout)/workout-session.tsx
@@ -604,6 +604,7 @@ export default function WorkoutSessionScreen() {
               timeMin={currentSet?.time || 0}
               currentSetCompleted={currentSetCompleted}
               isWarmup={currentSet?.isWarmup || false}
+              isDropSet={currentSet?.isDropSet || false}
               trackingType={currentExercise?.tracking_type || "weight"}
               handleWeightInputChange={handleWeightInputChange}
               handleWeightChange={handleWeightChange}
@@ -655,6 +656,7 @@ export default function WorkoutSessionScreen() {
                 timeMin={upcomingSet?.time || 0}
                 currentSetCompleted={false}
                 isWarmup={upcomingSet?.isWarmup || false}
+                isDropSet={upcomingSet?.isDropSet || false}
                 trackingType={nextExercise?.tracking_type || "weight"}
                 handleWeightInputChange={() => {}}
                 handleWeightChange={() => {}}
@@ -709,6 +711,7 @@ export default function WorkoutSessionScreen() {
                   timeMin={previousSet?.time || 0}
                   currentSetCompleted={previousSetCompleted}
                   isWarmup={previousSet?.isWarmup || false}
+                  isDropSet={previousSet?.isDropSet || false}
                   trackingType={previousExercise?.tracking_type || "weight"}
                   handleWeightInputChange={() => {}}
                   handleWeightChange={() => {}}

--- a/components/EditSetModal.tsx
+++ b/components/EditSetModal.tsx
@@ -55,6 +55,7 @@ export const EditSetModal: React.FC<EditSetModalProps> = ({
 
   const [applyToAllSets, setApplyToAllSets] = useState(false);
   const [isWarmup, setIsWarmup] = useState(set?.isWarmup ?? false);
+  const [isDropSet, setIsDropSet] = useState(set?.isDropSet ?? false);
 
   const [repsMin, setRepsMin] = useState(
     set?.repsMin !== undefined && set?.repsMin !== null
@@ -95,6 +96,7 @@ export const EditSetModal: React.FC<EditSetModalProps> = ({
       );
       setTime(set.time ? formatFromTotalSeconds(set.time) : "00:00");
       setIsWarmup(set?.isWarmup ?? false);
+      setIsDropSet(set?.isDropSet ?? false);
     } else {
       if (trackingType === "time") {
         setTime(formatFromTotalSeconds(defaultTime));
@@ -136,6 +138,7 @@ export const EditSetModal: React.FC<EditSetModalProps> = ({
       restSeconds: totalSeconds % 60,
       time: timeToSave,
       isWarmup,
+      isDropSet,
     };
 
     if (applyToAllSets) {
@@ -271,8 +274,17 @@ export const EditSetModal: React.FC<EditSetModalProps> = ({
                   onPress={() => setIsWarmup(!isWarmup)}
                 />
                 <ThemedText style={styles.checkboxLabel}>
-                  Warm-up Set
+                  Warm-up set
                 </ThemedText>
+              </View>
+
+              <View style={styles.checkboxContainer}>
+                <Checkbox
+                  status={isDropSet ? "checked" : "unchecked"}
+                  uncheckedColor={Colors.dark.subText}
+                  onPress={() => setIsDropSet(!isDropSet)}
+                />
+                <ThemedText style={styles.checkboxLabel}>Drop set</ThemedText>
               </View>
 
               <View style={styles.checkboxContainer}>

--- a/components/SessionSetInfo.tsx
+++ b/components/SessionSetInfo.tsx
@@ -30,6 +30,7 @@ interface SessionSetInfoProps {
   timeMin: number | undefined;
   currentSetCompleted: boolean;
   isWarmup: boolean;
+  isDropSet: boolean;
   trackingType: string;
   handleWeightInputChange: (text: string) => void;
   handleWeightChange: (amount: number) => void;
@@ -64,6 +65,7 @@ export default function SessionSetInfo({
   timeMin,
   currentSetCompleted,
   isWarmup,
+  isDropSet,
   trackingType,
   handleWeightInputChange,
   handleWeightChange,
@@ -167,6 +169,11 @@ export default function SessionSetInfo({
       {isWarmup && (
         <View style={styles.centeredLabelContainer}>
           <ThemedText style={styles.warmupLabel}>Warm-up</ThemedText>
+        </View>
+      )}
+      {isDropSet && (
+        <View style={styles.centeredLabelContainer}>
+          <ThemedText style={styles.warmupLabel}>Drop set</ThemedText>
         </View>
       )}
 

--- a/components/SessionSetInfo.tsx
+++ b/components/SessionSetInfo.tsx
@@ -396,7 +396,7 @@ const styles = StyleSheet.create({
     marginTop: 8,
   },
   buttonLabel: {
-    fontSize: 18,
+    fontSize: 16,
   },
   largeButtonLabel: {
     fontSize: 24,

--- a/components/SessionSetInfo.tsx
+++ b/components/SessionSetInfo.tsx
@@ -6,6 +6,7 @@ import { ThemedText } from "@/components/ThemedText";
 import { Colors } from "@/constants/Colors";
 import { TouchableOpacity } from "react-native";
 import { router } from "expo-router";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
 
 const fallbackImage = require("@/assets/images/placeholder.webp");
 
@@ -168,12 +169,24 @@ export default function SessionSetInfo({
 
       {isWarmup && (
         <View style={styles.centeredLabelContainer}>
-          <ThemedText style={styles.warmupLabel}>Warm-up</ThemedText>
+          <MaterialCommunityIcons
+            name="speedometer-slow"
+            size={24}
+            color={Colors.dark.text}
+            style={styles.setIcon}
+          />
+          <ThemedText style={styles.setTypeLabel}>Warm-up</ThemedText>
         </View>
       )}
       {isDropSet && (
         <View style={styles.centeredLabelContainer}>
-          <ThemedText style={styles.warmupLabel}>Drop set</ThemedText>
+          <MaterialCommunityIcons
+            name="arrow-down-bold"
+            size={24}
+            color={Colors.dark.text}
+            style={styles.setIcon}
+          />
+          <ThemedText style={styles.setTypeLabel}>Drop set</ThemedText>
         </View>
       )}
 
@@ -327,11 +340,15 @@ const styles = StyleSheet.create({
     marginBottom: "auto",
   },
   centeredLabelContainer: {
-    alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "center",
   },
-  warmupLabel: {
+  setTypeLabel: {
     fontSize: 20,
     marginBottom: 16,
+  },
+  setIcon: {
+    marginRight: 8,
   },
   label: {
     fontSize: 16,

--- a/components/SessionSetInfo.tsx
+++ b/components/SessionSetInfo.tsx
@@ -168,7 +168,7 @@ export default function SessionSetInfo({
       </View>
 
       {isWarmup && (
-        <View style={styles.centeredLabelContainer}>
+        <View style={styles.setTypeLabelContainer}>
           <MaterialCommunityIcons
             name="speedometer-slow"
             size={24}
@@ -179,7 +179,7 @@ export default function SessionSetInfo({
         </View>
       )}
       {isDropSet && (
-        <View style={styles.centeredLabelContainer}>
+        <View style={styles.setTypeLabelContainer}>
           <MaterialCommunityIcons
             name="arrow-down-bold"
             size={24}
@@ -340,8 +340,12 @@ const styles = StyleSheet.create({
     marginBottom: "auto",
   },
   centeredLabelContainer: {
+    alignItems: "center",
+  },
+  setTypeLabelContainer: {
     flexDirection: "row",
     justifyContent: "center",
+    marginBottom: 16,
   },
   setTypeLabel: {
     fontSize: 20,

--- a/hooks/useCreatePlan.ts
+++ b/hooks/useCreatePlan.ts
@@ -54,6 +54,7 @@ export const useCreatePlan = (
       if (!isError && planSaved) {
         clearWorkouts();
         queryClient.invalidateQueries({ queryKey: ["plans"] });
+        queryClient.invalidateQueries({ queryKey: ["activePlan"] });
       }
     }
   };

--- a/store/activeWorkoutStore.ts
+++ b/store/activeWorkoutStore.ts
@@ -142,6 +142,15 @@ const useActiveWorkoutStore = create<ActiveWorkoutStore>()(
           const isWarmup =
             currentExercise.sets[currentSetIndex]?.isWarmup || false;
 
+          // Check if current set is a drop set
+          const isDropSet =
+            currentExercise.sets[currentSetIndex]?.isDropSet || false;
+
+          // Check if next set is drop set
+          const isNextDropSet =
+            nextSetIndex < currentExercise.sets.length &&
+            currentExercise.sets[nextSetIndex]?.isDropSet;
+
           // Update the set index for the current exercise
           const updatedSetIndices = {
             ...currentSetIndices,
@@ -164,7 +173,8 @@ const useActiveWorkoutStore = create<ActiveWorkoutStore>()(
             ...(trackingType === "weight" || trackingType === ""
               ? {
                   weight:
-                    isWarmup && nextSetValues?.weight
+                    (isWarmup || isDropSet || isNextDropSet) &&
+                    nextSetValues?.weight
                       ? nextSetValues.weight.toString()
                       : currentSetValues.weight,
                   reps:
@@ -176,7 +186,8 @@ const useActiveWorkoutStore = create<ActiveWorkoutStore>()(
             ...(trackingType === "assisted"
               ? {
                   weight:
-                    isWarmup && nextSetValues?.weight
+                    (isWarmup || isDropSet || isNextDropSet) &&
+                    nextSetValues?.weight
                       ? nextSetValues.weight.toString()
                       : currentSetValues.weight,
                   reps:

--- a/store/workoutStore.ts
+++ b/store/workoutStore.ts
@@ -8,6 +8,7 @@ export interface Set {
   restSeconds: number;
   time: number | undefined;
   isWarmup?: boolean;
+  isDropSet?: boolean;
 }
 
 export interface UserExercise extends Exercise {

--- a/utils/database.ts
+++ b/utils/database.ts
@@ -67,7 +67,7 @@ export const updateAppExerciseIds = async (): Promise<void> => {
 
     if (dataVersion === "1.1") {
       console.log(
-        "Data version is 1. Updating app_exercise_id for exercises...",
+        "Data version is 1.1. Updating app_exercise_id for exercises...",
       );
 
       // Find all exercises where app_exercise_id is NULL
@@ -97,9 +97,14 @@ export const updateAppExerciseIds = async (): Promise<void> => {
         console.log("Updated data version to 1.2...");
       } else {
         console.log("No exercises with NULL app_exercise_id found.");
+        await userDataDB.runAsync(
+          "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+          ["dataVersion", "1.2"],
+        );
+        console.log("Updated data version to 1.2...");
       }
     } else {
-      console.log("Data version is not 1. No update needed.");
+      console.log("Data version is not 1.1. No update needed.");
     }
   } catch (error) {
     console.error("Error updating app_exercise_id:", error);


### PR DESCRIPTION
## Summary by Sourcery

Add support for drop sets in the workout session feature, allowing users to specify and manage drop sets. Enhance the UI to visually distinguish between different set types using icons.

New Features:
- Introduce the concept of 'drop sets' in the workout session, allowing users to mark sets as drop sets and handle them accordingly in the UI and logic.

Enhancements:
- Refactor the UI to include icons for set types, such as warm-up and drop sets, improving the visual representation of different set types.