### PR TITLE
feat: disable select exercises button if nothing selected

### DIFF
--- a/app/(app)/(create-plan)/exercises.tsx
+++ b/app/(app)/(create-plan)/exercises.tsx
@@ -174,6 +174,7 @@ export default function ExercisesScreen() {
             <Button
               mode={selectedExercises.length > 0 ? "contained" : "outlined"}
               compact
+              disabled={selectedExercises.length === 0}
               onPress={handleAddExercise}
               labelStyle={styles.addButtonLabel}
             >

--- a/app/(app)/(tabs)/(stats)/exercises.tsx
+++ b/app/(app)/(tabs)/(stats)/exercises.tsx
@@ -172,6 +172,7 @@ export default function ExercisesScreen() {
             <Button
               mode={selectedExercises.length > 0 ? "contained" : "outlined"}
               compact
+              disabled={selectedExercises.length === 0}
               onPress={handleAddExercise}
               labelStyle={styles.addButtonLabel}
             >


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Disable the 'Select Exercises' button when no exercises are selected to prevent users from proceeding without making a selection.