### PR TITLE
feat: add dev function to reset active plan status

### DIFF
--- a/app/(app)/(tabs)/settings.tsx
+++ b/app/(app)/(tabs)/settings.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import {
   ScrollView,
   StyleSheet,
@@ -27,6 +27,7 @@ import { openDatabase } from "@/utils/database";
 import { AuthContext } from "@/context/AuthProvider";
 import { signInWithGoogle } from "@/utils/auth";
 import Bugsnag from "@bugsnag/expo";
+import { clearActivePlanStatus } from "@/utils/clearUserData";
 
 export default function SettingsScreen() {
   const user = useContext(AuthContext);
@@ -613,7 +614,10 @@ export default function SettingsScreen() {
 
         {/* <View style={styles.section}>
           <ThemedText style={styles.sectionHeader}>Manage Data</ThemedText>
-          <TouchableOpacity style={styles.item} onPress={confirmClearDatabase}>
+          <TouchableOpacity
+            style={styles.item}
+            // onPress={confirmClearDatabase}
+          >
             <MaterialCommunityIcons
               name="delete"
               size={24}
@@ -628,7 +632,7 @@ export default function SettingsScreen() {
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.item}
-            onPress={resetLoginShownSetting}
+            // onPress={resetLoginShownSetting}
           >
             <MaterialCommunityIcons
               name="delete"
@@ -653,8 +657,19 @@ export default function SettingsScreen() {
               style={styles.icon}
             />
             <View style={styles.textContainer}>
+              <ThemedText style={styles.itemText}>Send test error</ThemedText>
+            </View>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.item} onPress={clearActivePlanStatus}>
+            <MaterialCommunityIcons
+              name="bug"
+              size={24}
+              color={Colors.dark.icon}
+              style={styles.icon}
+            />
+            <View style={styles.textContainer}>
               <ThemedText style={styles.itemText}>
-                Send test error
+                Clear Active Plan Status
               </ThemedText>
             </View>
           </TouchableOpacity>

--- a/utils/clearUserData.ts
+++ b/utils/clearUserData.ts
@@ -1,6 +1,7 @@
 import Bugsnag from "@bugsnag/expo";
 import * as FileSystem from "expo-file-system";
 import * as Updates from "expo-updates";
+import { openDatabase } from "./database";
 
 export const clearDatabaseAndReinitialize = async () => {
   const dbPath = `${FileSystem.documentDirectory}SQLite/userData.db`;
@@ -20,5 +21,18 @@ export const clearDatabaseAndReinitialize = async () => {
   } catch (error: any) {
     Bugsnag.notify(error);
     console.error("Error clearing and reinitializing the database:", error);
+  }
+};
+
+export const clearActivePlanStatus = async () => {
+  try {
+    const db = await openDatabase("userData.db");
+    await db.runAsync(
+      `UPDATE user_plans SET is_active = false WHERE is_active = true`,
+    );
+    await Updates.reloadAsync();
+  } catch (error: any) {
+    Bugsnag.notify(error);
+    console.error("Error clearing active plan status:", error);
   }
 };


### PR DESCRIPTION
## Summary by Sourcery

Add a new feature to reset the active status of user plans through a new function and integrate it into the settings screen with a dedicated button.

New Features:
- Introduce a new function 'clearActivePlanStatus' to reset the active status of user plans in the database.

Enhancements:
- Add a new button in the settings screen to trigger the 'clearActivePlanStatus' function.