### PR TITLE
fix: stats spacing and query cache time

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -4,7 +4,7 @@ export default {
   expo: {
     name: IS_DEV ? "Muscle Quest (Dev)" : "Muscle Quest",
     slug: "musclequest",
-    version: "0.8.13",
+    version: "0.8.14",
     orientation: "portrait",
     icon: "./assets/images/icon.png",
     scheme: "myapp",

--- a/components/charts/ExerciseProgressionChart.tsx
+++ b/components/charts/ExerciseProgressionChart.tsx
@@ -151,7 +151,7 @@ export const ExerciseProgressionChart: React.FC<
         )}
         <LineChart
           data={chartData}
-          spacing={35}
+          spacing={30}
           thickness={5}
           color={Colors.dark.highlight}
           isAnimated
@@ -198,7 +198,7 @@ const styles = StyleSheet.create({
     color: Colors.dark.text,
   },
   xAxisLabel: {
-    fontSize: 10,
+    fontSize: 9,
     color: Colors.dark.text,
     marginTop: 4,
   },

--- a/components/charts/WorkoutBarChart.tsx
+++ b/components/charts/WorkoutBarChart.tsx
@@ -66,7 +66,7 @@ export const WorkoutBarChart: React.FC<WorkoutBarChartProps> = ({
   }));
 
   const barWidth = timeRange === "30" ? 35 : 15;
-  const barSpacing = timeRange === "30" ? 30 : timeRange === "90" ? 17 : 6;
+  const barSpacing = timeRange === "30" ? 20 : timeRange === "90" ? 15 : 6;
 
   return (
     <Card style={styles.card}>
@@ -102,7 +102,7 @@ const styles = StyleSheet.create({
     color: Colors.dark.text,
   },
   xAxisLabel: {
-    fontSize: 10,
+    fontSize: 9,
     color: Colors.dark.text,
     marginTop: 4,
   },

--- a/hooks/useActivePlanQuery.ts
+++ b/hooks/useActivePlanQuery.ts
@@ -99,6 +99,6 @@ export const useActivePlanQuery = () => {
   return useQuery<Plan | null>({
     queryKey: ["activePlan"],
     queryFn: fetchActivePlanData,
-    staleTime: Infinity,
+    staleTime: 5 * 60 * 1000,
   });
 };

--- a/hooks/useAllPlansQuery.ts
+++ b/hooks/useAllPlansQuery.ts
@@ -146,6 +146,6 @@ export const useAllPlansQuery = () => {
   return useQuery<{ userPlans: Plan[]; appPlans: Plan[] }, Error>({
     queryKey: ["plans"],
     queryFn: fetchPlans,
-    staleTime: Infinity,
+    staleTime: 5 * 60 * 1000,
   });
 };

--- a/hooks/useCompletedWorkoutsQuery.ts
+++ b/hooks/useCompletedWorkoutsQuery.ts
@@ -189,6 +189,6 @@ export const useCompletedWorkoutsQuery = (
   return useQuery<CompletedWorkout[]>({
     queryKey: ["completedWorkouts", weightUnit],
     queryFn: () => fetchAndOrganize(weightUnit, timeRange),
-    staleTime: Infinity,
+    staleTime: 5 * 60 * 1000,
   });
 };

--- a/hooks/useExerciseDetailsQuery.ts
+++ b/hooks/useExerciseDetailsQuery.ts
@@ -10,6 +10,6 @@ export const useExerciseDetailsQuery = (exercise_id: number) => {
         "exercises",
         exercise_id,
       ) as unknown as Exercise,
-    staleTime: Infinity,
+    staleTime: 5 * 60 * 1000,
   });
 };

--- a/hooks/useSettingsQuery.ts
+++ b/hooks/useSettingsQuery.ts
@@ -5,5 +5,6 @@ export const useSettingsQuery = () => {
   return useQuery({
     queryKey: ["settings"],
     queryFn: fetchSettings,
+    staleTime: 5 * 60 * 1000, // 5 minutes
   });
 };

--- a/hooks/useSettingsQuery.ts
+++ b/hooks/useSettingsQuery.ts
@@ -5,6 +5,5 @@ export const useSettingsQuery = () => {
   return useQuery({
     queryKey: ["settings"],
     queryFn: fetchSettings,
-    staleTime: Infinity,
   });
 };

--- a/hooks/useTrackedExercisesQuery.ts
+++ b/hooks/useTrackedExercisesQuery.ts
@@ -123,6 +123,5 @@ export const useTrackedExercisesQuery = (timeRange: string) => {
   return useQuery<TrackedExerciseWithSets[], Error>({
     queryKey: ["trackedExercises"],
     queryFn: () => fetchTrackedExercises(timeRange),
-    staleTime: Infinity,
   });
 };

--- a/hooks/useTrackedExercisesQuery.ts
+++ b/hooks/useTrackedExercisesQuery.ts
@@ -123,5 +123,6 @@ export const useTrackedExercisesQuery = (timeRange: string) => {
   return useQuery<TrackedExerciseWithSets[], Error>({
     queryKey: ["trackedExercises"],
     queryFn: () => fetchTrackedExercises(timeRange),
+    staleTime: 5 * 60 * 1000,
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "musclequest",
   "main": "expo-router/entry",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "scripts": {
     "dev": "APP_VARIANT=development npx expo start",
     "build-dev": "npx eas build --profile development --platform android",


### PR DESCRIPTION
## Summary by Sourcery

Update chart spacing and font sizes. Set the query cache time to 5 minutes.