### PR TITLE
fix: calculate elapsed time for workout timer

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -4,7 +4,7 @@ export default {
   expo: {
     name: IS_DEV ? "Muscle Quest (Dev)" : "Muscle Quest",
     slug: "musclequest",
-    version: "0.8.18",
+    version: "0.8.20",
     orientation: "portrait",
     icon: "./assets/images/icon.png",
     scheme: "myapp",
@@ -19,7 +19,7 @@ export default {
       bundleIdentifier: "com.isotronic.musclequest",
     },
     android: {
-      versionCode: 818,
+      versionCode: 820,
       googleServicesFile: "./google-services.json",
       adaptiveIcon: {
         foregroundImage: "./assets/images/ic_launcher_foreground.png",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "musclequest",
   "main": "expo-router/entry",
-  "version": "0.8.17",
   "scripts": {
     "dev": "APP_VARIANT=development npx expo start",
     "build-dev": "npx eas build --profile development --platform android",


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correctly calculate the elapsed time for the workout timer, addressing an issue where the timer was inaccurate after resuming from a background state.