### PR TITLE
feat: show / hide onboarding from settings

### DIFF
--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -173,6 +173,7 @@ export default function HomeScreen() {
         <View style={styles.cardContainer}>
           {activePlan && settings ? (
             <>
+              {settings.showOnboarding === "true" && <Onboarding />}
               <ThemedText type="default" style={styles.sectionTitle}>
                 Active Plan: {activePlan.name}
               </ThemedText>

--- a/app/(app)/(tabs)/settings.tsx
+++ b/app/(app)/(tabs)/settings.tsx
@@ -85,6 +85,7 @@ export default function SettingsScreen() {
     restTimerVibration: settings?.restTimerVibration,
     restTimerSound: settings?.restTimerSound,
     restTimerNotification: settings?.restTimerNotification,
+    showOnboarding: settings?.showOnboarding,
   });
 
   const defaultRestTime = settings
@@ -108,6 +109,7 @@ export default function SettingsScreen() {
         restTimerVibration: settings?.restTimerVibration,
         restTimerSound: settings?.restTimerSound,
         restTimerNotification: settings?.restTimerNotification,
+        showOnboarding: settings?.showOnboarding,
       });
     }
   }, [settings]);
@@ -185,6 +187,11 @@ export default function SettingsScreen() {
 
   const cancelOverlay = () => {
     setOverlayVisible(false);
+  };
+
+  const toggleOnboarding = (value: boolean) => {
+    setToggleValues({ ...toggleValues, showOnboarding: value.toString() });
+    updateSetting({ key: "showOnboarding", value: value.toString() });
   };
 
   const toggleKeepScreenOn = (value: boolean) => {
@@ -716,6 +723,28 @@ export default function SettingsScreen() {
 
         <View style={styles.section}>
           <ThemedText style={styles.sectionHeader}>Appearance</ThemedText>
+          <View style={styles.item}>
+            <MaterialCommunityIcons
+              name="view-dashboard"
+              size={24}
+              color={Colors.dark.icon}
+              style={styles.icon}
+            />
+            <View style={styles.textContainer}>
+              <ThemedText style={styles.itemText}>
+                Show onboarding on home screen
+              </ThemedText>
+              <ThemedText style={styles.currentSetting}>
+                {settings?.showOnboarding === "true" ? "Enabled" : "Disabled"}
+              </ThemedText>
+            </View>
+            <Switch
+              value={settings?.showOnboarding === "true"}
+              onValueChange={toggleOnboarding}
+              color={Colors.dark.tint}
+              style={styles.switch}
+            />
+          </View>
           <TouchableOpacity
             style={styles.item}
             onPress={() =>

--- a/components/Onboarding.tsx
+++ b/components/Onboarding.tsx
@@ -41,6 +41,13 @@ const onboardingData = [
     buttonLabel: "Create a Plan",
     route: "/(create-plan)/create",
   },
+  {
+    title: "Hide / Show Onboarding",
+    description:
+      "You can hide this onboarding screen at any time from the settings page in the appearance section. If you ever want to revisit the onboarding, you can enable it again from the same settings page.",
+    buttonLabel: "Go to Settings",
+    route: "/settings",
+  },
 ];
 
 const Onboarding = () => {

--- a/components/Onboarding.tsx
+++ b/components/Onboarding.tsx
@@ -111,6 +111,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
+    paddingBottom: 16,
   },
   card: {
     width: 320,

--- a/utils/database.ts
+++ b/utils/database.ts
@@ -874,6 +874,7 @@ export const insertDefaultSettings = async () => {
     { key: "restTimerSound", value: "false" },
     { key: "restTimerNotification", value: "false" },
     { key: "loginShown", value: "false" },
+    { key: "showOnboarding", value: "true" },
     { key: "bodyWeight", value: "70" },
   ];
 
@@ -917,6 +918,7 @@ export interface Settings {
   restTimerNotification: string;
   bodyWeight: string;
   loginShown: string;
+  showOnboarding: string;
 }
 
 export const fetchSettings = async (): Promise<Settings> => {


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Users can now choose to show or hide the onboarding screen from the settings page in the appearance section.