### PR TITLE
feat: add "to failure" as a new set option

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -4,7 +4,7 @@ export default {
   expo: {
     name: IS_DEV ? "Muscle Quest (Dev)" : "Muscle Quest",
     slug: "musclequest",
-    version: "0.14.0", // MM.mm.pp
+    version: "0.15.0", // MM.mm.pp
     orientation: "portrait",
     icon: "./assets/images/icon.png",
     scheme: "musclequest",
@@ -19,7 +19,7 @@ export default {
       bundleIdentifier: "com.isotronic.musclequest",
     },
     android: {
-      versionCode: 1400, // MMmmpp
+      versionCode: 1500, // MMmmpp
       googleServicesFile: "./google-services.json",
       adaptiveIcon: {
         foregroundImage: "./assets/images/ic_launcher_foreground.png",

--- a/app.config.js
+++ b/app.config.js
@@ -4,7 +4,7 @@ export default {
   expo: {
     name: IS_DEV ? "Muscle Quest (Dev)" : "Muscle Quest",
     slug: "musclequest",
-    version: "0.15.0", // MM.mm.pp
+    version: "0.16.0", // MM.mm.pp
     orientation: "portrait",
     icon: "./assets/images/icon.png",
     scheme: "musclequest",
@@ -19,7 +19,7 @@ export default {
       bundleIdentifier: "com.isotronic.musclequest",
     },
     android: {
-      versionCode: 1500, // MMmmpp
+      versionCode: 1600, // MMmmpp
       googleServicesFile: "./google-services.json",
       adaptiveIcon: {
         foregroundImage: "./assets/images/ic_launcher_foreground.png",

--- a/app/(app)/(create-plan)/sets-overview.tsx
+++ b/app/(app)/(create-plan)/sets-overview.tsx
@@ -78,6 +78,7 @@ export default function SetsOverviewScreen() {
               <ThemedText style={styles.setInfo}>
                 {item.isWarmup ? "Warm-up, " : ""}
                 {item.isDropSet ? "Drop set, " : ""}
+                {item.isToFailure ? "To failure, " : ""}
                 {trackingType === "time"
                   ? `${formattedTime}, `
                   : repRange !== undefined

--- a/app/(app)/(tabs)/(plans)/workout-details.tsx
+++ b/app/(app)/(tabs)/(plans)/workout-details.tsx
@@ -5,7 +5,7 @@ import { router, Stack, useLocalSearchParams } from "expo-router";
 import { usePlanQuery } from "@/hooks/usePlanQuery";
 import { UserExercise } from "@/store/workoutStore";
 import { Image } from "expo-image";
-import { byteArrayToBase64 } from "@/utils/utility";
+import { byteArrayToBase64, formatFromTotalSeconds } from "@/utils/utility";
 import { TouchableOpacity } from "react-native";
 import { Colors } from "@/constants/Colors";
 import Bugsnag from "@bugsnag/expo";
@@ -47,14 +47,16 @@ export default function WorkoutDetailsScreen() {
 
     let timeRange;
     if (minTime === Infinity && maxTime !== -Infinity) {
-      timeRange = `${maxTime}`; // Only show maxTime if minTime is undefined
+      timeRange = `${formatFromTotalSeconds(maxTime)}`; // Only show maxTime if minTime is undefined
     } else if (maxTime === -Infinity && minTime !== Infinity) {
-      timeRange = `${minTime}`; // Only show minTime if maxTime is undefined
+      timeRange = `${formatFromTotalSeconds(minTime)}`; // Only show minTime if maxTime is undefined
     } else if (minTime === maxTime) {
-      timeRange = `${minTime}`; //Only show minTime if both are the same
+      timeRange = `${formatFromTotalSeconds(minTime)}`; //Only show minTime if both are the same
     } else if (minTime !== Infinity && maxTime !== -Infinity) {
-      timeRange = `${minTime} - ${maxTime}`; // Show range if both are defined
+      timeRange = `${formatFromTotalSeconds(minTime)} - ${formatFromTotalSeconds(maxTime)}`; // Show range if both are defined
     }
+
+    const isToFailure = item.sets.some((set) => set.isToFailure);
 
     const exerciseItem = { ...item, image: undefined };
 
@@ -91,10 +93,10 @@ export default function WorkoutDetailsScreen() {
                 : "No Sets Available"}
               {item.tracking_type === "time"
                 ? timeRange
-                  ? ` | ${timeRange} Seconds`
+                  ? ` | ${timeRange} ${isToFailure ? "(to Failure)" : ""}`
                   : ""
                 : repRange
-                  ? ` | ${repRange} Reps`
+                  ? ` | ${repRange} ${isToFailure ? "(to Failure) " : ""}Reps`
                   : ""}
             </ThemedText>
           </View>

--- a/app/(app)/(workout)/workout-session.tsx
+++ b/app/(app)/(workout)/workout-session.tsx
@@ -721,6 +721,7 @@ export default function WorkoutSessionScreen() {
               currentSetCompleted={currentSetCompleted}
               isWarmup={currentSet?.isWarmup || false}
               isDropSet={currentSet?.isDropSet || false}
+              isToFailure={currentSet?.isToFailure || false}
               trackingType={currentExercise?.tracking_type || "weight"}
               handleWeightInputChange={handleWeightInputChange}
               handleWeightChange={handleWeightChange}
@@ -774,6 +775,7 @@ export default function WorkoutSessionScreen() {
                 currentSetCompleted={false}
                 isWarmup={upcomingSet?.isWarmup || false}
                 isDropSet={upcomingSet?.isDropSet || false}
+                isToFailure={upcomingSet?.isToFailure || false}
                 trackingType={nextExercise?.tracking_type || "weight"}
                 handleWeightInputChange={() => {}}
                 handleWeightChange={() => {}}
@@ -830,6 +832,7 @@ export default function WorkoutSessionScreen() {
                   currentSetCompleted={previousSetCompleted}
                   isWarmup={previousSet?.isWarmup || false}
                   isDropSet={previousSet?.isDropSet || false}
+                  isToFailure={previousSet?.isToFailure || false}
                   trackingType={previousExercise?.tracking_type || "weight"}
                   handleWeightInputChange={() => {}}
                   handleWeightChange={() => {}}

--- a/components/EditSetModal.tsx
+++ b/components/EditSetModal.tsx
@@ -112,18 +112,16 @@ export const EditSetModal: React.FC<EditSetModalProps> = ({
     }
   };
 
+  const parseReps = (toFailure: boolean, reps: string): number | undefined => {
+    if (toFailure) return undefined;
+    if (reps === "") return undefined;
+    return Number(reps);
+  };
+
   const handleSaveSet = () => {
     const totalSeconds = convertToTotalSeconds(restTime);
-    const minReps = isToFailure
-      ? undefined
-      : repsMin === ""
-        ? undefined
-        : Number(repsMin);
-    const maxReps = isToFailure
-      ? undefined
-      : repsMax === ""
-        ? undefined
-        : Number(repsMax);
+    const minReps = parseReps(isToFailure, repsMin);
+    const maxReps = parseReps(isToFailure, repsMax);
     const timeToSave = convertToTotalSeconds(time || "00:00");
 
     const updatedSet = {

--- a/components/SessionSetInfo.tsx
+++ b/components/SessionSetInfo.tsx
@@ -41,6 +41,7 @@ interface SessionSetInfoProps {
   currentSetCompleted: boolean;
   isWarmup: boolean;
   isDropSet: boolean;
+  isToFailure: boolean;
   trackingType: string;
   handleWeightInputChange: (text: string) => void;
   handleWeightChange: (amount: number) => void;
@@ -78,6 +79,7 @@ export default function SessionSetInfo({
   currentSetCompleted,
   isWarmup,
   isDropSet,
+  isToFailure,
   trackingType,
   handleWeightInputChange,
   handleWeightChange,
@@ -201,7 +203,7 @@ export default function SessionSetInfo({
           disabled={isFirstSetOfFirstExercise}
           iconColor={Colors.dark.text}
         />
-        {(isWarmup || isDropSet) && (
+        {(isWarmup || isDropSet || isToFailure) && (
           <View style={styles.setTypeContainer}>
             {isWarmup && (
               <>
@@ -223,6 +225,17 @@ export default function SessionSetInfo({
                   style={styles.setIcon}
                 />
                 <ThemedText style={styles.setTypeLabel}>Drop</ThemedText>
+              </>
+            )}
+            {isToFailure && (
+              <>
+                <MaterialCommunityIcons
+                  name="fire"
+                  size={24}
+                  color={Colors.dark.text}
+                  style={styles.setIcon}
+                />
+                <ThemedText style={styles.setTypeLabel}>To Failure</ThemedText>
               </>
             )}
           </View>

--- a/components/WorkoutCard.tsx
+++ b/components/WorkoutCard.tsx
@@ -116,6 +116,8 @@ export default function WorkoutCard({
         timeRange = `${formatFromTotalSeconds(minTime)} - ${formatFromTotalSeconds(maxTime)}`;
       }
 
+      const isToFailure = item.sets.some((set) => set.isToFailure);
+
       const isMenuOpen = menuVisible === item.exercise_id;
 
       return (
@@ -141,10 +143,10 @@ export default function WorkoutCard({
                 : "No Sets Available"}
               {item.tracking_type === "time"
                 ? timeRange
-                  ? ` | ${timeRange}`
+                  ? ` | ${timeRange} ${isToFailure ? "(to Failure)" : ""}`
                   : ""
                 : repRange
-                  ? ` | ${repRange} Reps`
+                  ? ` | ${repRange} ${isToFailure ? "(to Failure) " : ""}Reps`
                   : ""}
             </ThemedText>
           </View>

--- a/constants/WhatsNew.ts
+++ b/constants/WhatsNew.ts
@@ -17,4 +17,12 @@ export const WHATS_NEW_ENTRIES: WhatsNewEntry[] = [
 You can now add notes to exercises, workouts and plans. Use this to jot down technique tips, machine settings, reminders, or anything else that helps you crush your session!
 `,
   },
+  {
+    version: 1600,
+    message: `
+🔥 New Feature: To Failure Sets!
+
+You can now mark a set to "To Failure" to indicate that you want to complete the set to failure. Especially useful for isolation machine, dumbbell, or bodyweight exercises, where you want to push yourself to the limit.
+`,
+  },
 ];

--- a/hooks/usePlanQuery.ts
+++ b/hooks/usePlanQuery.ts
@@ -26,6 +26,7 @@ export interface WorkoutRecord {
       restSeconds: number;
       time: number;
       isWarmup: boolean;
+      toFailure: boolean;
     }[];
   }[];
 }

--- a/store/workoutStore.ts
+++ b/store/workoutStore.ts
@@ -9,6 +9,7 @@ export interface Set {
   time: number | undefined;
   isWarmup?: boolean;
   isDropSet?: boolean;
+  isToFailure?: boolean;
 }
 
 export interface UserExercise extends Exercise {


### PR DESCRIPTION
## Summary by Sourcery

Add support for "to failure" sets as a new set option in the workout tracking application

New Features:
- Introduce a new 'To Failure' set option that allows users to mark sets where they intend to perform exercises until muscle failure

Enhancements:
- Update UI components to display and handle the new 'To Failure' set type
- Modify set creation and editing workflows to support the new set option

Chores:
- Update app version to 0.16.0
- Add a What's New entry to highlight the new feature