### PR TITLE
fix: WorkoutSessionScreen by removing animation

### DIFF
--- a/components/WhatsNewModal.tsx
+++ b/components/WhatsNewModal.tsx
@@ -5,7 +5,7 @@ import { ThemedText } from "@/components/ThemedText";
 import { useSettingsQuery } from "@/hooks/useSettingsQuery";
 import { useUpdateSettingsMutation } from "@/hooks/useUpdateSettingsMutation";
 import {
-  CURRENT_APP_VERSION,
+  CURRENT_WHATS_NEW_VERSION,
   WHATS_NEW_ENTRIES,
   WhatsNewEntry,
 } from "@/constants/WhatsNew";
@@ -37,7 +37,7 @@ export const WhatsNewModal = () => {
     } else {
       setSetting({
         key: "lastSeenVersion",
-        value: CURRENT_APP_VERSION.toString(),
+        value: CURRENT_WHATS_NEW_VERSION.toString(),
       });
       setVisible(false);
     }

--- a/constants/WhatsNew.ts
+++ b/constants/WhatsNew.ts
@@ -1,20 +1,28 @@
-import Constants from "expo-constants";
-
 export interface WhatsNewEntry {
   version: number;
   message: string;
 }
 
-export const CURRENT_APP_VERSION =
-  Constants.expoConfig?.android?.versionCode || 0;
+// Increment this version whenever you push an EAS update with user-facing changes
+export const CURRENT_WHATS_NEW_VERSION = 2505;
 
 export const WHATS_NEW_ENTRIES: WhatsNewEntry[] = [
   {
-    version: 1704,
+    version: 2504,
     message: `
 🎯 Improved: Smart Filter Preselection!
 
 When replacing an exercise in your workout or plan, the body part filter is now automatically preselected to match the exercise you're replacing. This makes it much faster to find similar alternatives without extra tapping!
+`,
+  },
+  {
+    version: 2505,
+    message: `
+🐛 Fixed: Workout Session Button Issues!
+
+Fixed a critical bug where all buttons (increment/decrement, next/previous set, complete set) would stop working after completing a set during a workout. 
+
+The broken sliding animations between sets have been removed entirely. Set transitions now happen instantly, making the workout flow smoother and more responsive.
 `,
   },
 ];

--- a/constants/WhatsNew.ts
+++ b/constants/WhatsNew.ts
@@ -25,7 +25,11 @@ The broken sliding animations between sets have been removed entirely. Set trans
 ];
 
 // Derived from WHATS_NEW_ENTRIES to avoid drift between the constant and entries
-export const CURRENT_WHATS_NEW_VERSION = WHATS_NEW_ENTRIES.reduce(
-  (max, entry) => (entry.version > max ? entry.version : max),
-  0,
-);
+// Defaults to 0 if the array is empty
+export const CURRENT_WHATS_NEW_VERSION =
+  WHATS_NEW_ENTRIES.length > 0
+    ? WHATS_NEW_ENTRIES.reduce(
+        (max, entry) => (entry.version > max ? entry.version : max),
+        0,
+      )
+    : 0;

--- a/constants/WhatsNew.ts
+++ b/constants/WhatsNew.ts
@@ -3,9 +3,6 @@ export interface WhatsNewEntry {
   message: string;
 }
 
-// Increment this version whenever you push an EAS update with user-facing changes
-export const CURRENT_WHATS_NEW_VERSION = 2505;
-
 export const WHATS_NEW_ENTRIES: WhatsNewEntry[] = [
   {
     version: 2504,
@@ -26,3 +23,9 @@ The broken sliding animations between sets have been removed entirely. Set trans
 `,
   },
 ];
+
+// Derived from WHATS_NEW_ENTRIES to avoid drift between the constant and entries
+export const CURRENT_WHATS_NEW_VERSION = WHATS_NEW_ENTRIES.reduce(
+  (max, entry) => (entry.version > max ? entry.version : max),
+  0,
+);


### PR DESCRIPTION
## Summary by Sourcery

Remove animated swipe transitions from the workout session screen to restore reliable set navigation and button interactions, and update the Whats New system to track versions based on the entries list instead of the app build version.

Bug Fixes:
- Fix workout session controls becoming unresponsive after completing a set by simplifying set transitions and removing the broken animation layer.

Enhancements:
- Simplify WorkoutSessionScreen by using direct state updates for set navigation instead of gesture-driven animations and precomputed next/previous set data.
- Refine the Whats New version tracking to derive the current version from the defined entries, preventing drift from app configuration.

Documentation:
- Add a new Whats New entry describing the workout session button fix and removal of sliding animations.