### PR TITLE
fix: rest timer notification firing too soon

### DIFF
--- a/app/(app)/(tabs)/(stats)/history-details.tsx
+++ b/app/(app)/(tabs)/(stats)/history-details.tsx
@@ -307,6 +307,8 @@ const styles = StyleSheet.create({
   exerciseName: {
     fontSize: 20,
     fontWeight: "bold",
+    flex: 1,
+    flexWrap: "wrap",
   },
   setRow: {
     flexDirection: "row",

--- a/app/(app)/(workout)/workout-session.tsx
+++ b/app/(app)/(workout)/workout-session.tsx
@@ -192,15 +192,17 @@ export default function WorkoutSessionScreen() {
   const startRestTimer = (restMinutes: number, restSeconds: number) => {
     if (restMinutes > 0 || restSeconds > 0) {
       const totalSeconds = restMinutes * 60 + restSeconds;
-      cancelRestNotifications();
 
       if (settings?.restTimerNotification === "true") {
-        scheduleRestNotification(
-          totalSeconds,
-          "Rest Timer Finished!",
-          "Time to do your next set!",
-          "rest-timer1",
-        );
+        // Cancel first, then schedule - make sure they're awaited properly
+        cancelRestNotifications().then(() => {
+          scheduleRestNotification(
+            totalSeconds,
+            "Rest Timer Finished!",
+            "Time to do your next set!",
+            "rest-timer1",
+          );
+        });
       }
 
       const time = new Date();

--- a/app/(app)/(workout)/workout-session.tsx
+++ b/app/(app)/(workout)/workout-session.tsx
@@ -17,7 +17,7 @@ import WorkoutTimer from "@/components/WorkoutTimer";
 import Bugsnag from "@bugsnag/expo";
 import {
   cancelRestNotifications,
-  scheduleRestNotification,
+  scheduleRestNotificationWithCancellation,
 } from "@/utils/restNotification";
 import { Notes } from "@/components/Notes";
 import { convertTimeStrToSeconds } from "@/utils/utility";
@@ -193,17 +193,16 @@ export default function WorkoutSessionScreen() {
     if (restMinutes > 0 || restSeconds > 0) {
       const totalSeconds = restMinutes * 60 + restSeconds;
 
-      // Always cancel any existing notifications
-      await cancelRestNotifications();
-
-      // Only schedule a new notification if the setting is enabled
+      // Use wrapper that handles cancel-then-schedule or just cancel if notifications disabled
       if (settings?.restTimerNotification === "true") {
-        await scheduleRestNotification(
+        await scheduleRestNotificationWithCancellation(
           totalSeconds,
           "Rest Timer Finished!",
           "Time to do your next set!",
           "rest-timer1",
         );
+      } else {
+        await cancelRestNotifications();
       }
 
       const time = new Date();
@@ -402,7 +401,7 @@ export default function WorkoutSessionScreen() {
     );
 
     if (hasNextSet) {
-      startRestTimer(currentSet.restMinutes, currentSet.restSeconds);
+      void startRestTimer(currentSet.restMinutes, currentSet.restSeconds);
       // Update state immediately without animation
       nextSet();
     } else {

--- a/app/(app)/(workout)/workout-session.tsx
+++ b/app/(app)/(workout)/workout-session.tsx
@@ -189,20 +189,21 @@ export default function WorkoutSessionScreen() {
     }
   }, [timerRunning, timerExpiry, restart]);
 
-  const startRestTimer = (restMinutes: number, restSeconds: number) => {
+  const startRestTimer = async (restMinutes: number, restSeconds: number) => {
     if (restMinutes > 0 || restSeconds > 0) {
       const totalSeconds = restMinutes * 60 + restSeconds;
 
+      // Always cancel any existing notifications
+      await cancelRestNotifications();
+
+      // Only schedule a new notification if the setting is enabled
       if (settings?.restTimerNotification === "true") {
-        // Cancel first, then schedule - make sure they're awaited properly
-        cancelRestNotifications().then(() => {
-          scheduleRestNotification(
-            totalSeconds,
-            "Rest Timer Finished!",
-            "Time to do your next set!",
-            "rest-timer1",
-          );
-        });
+        await scheduleRestNotification(
+          totalSeconds,
+          "Rest Timer Finished!",
+          "Time to do your next set!",
+          "rest-timer1",
+        );
       }
 
       const time = new Date();

--- a/components/WeekDays.tsx
+++ b/components/WeekDays.tsx
@@ -80,6 +80,7 @@ const styles = StyleSheet.create({
   todayCircle: {},
   workoutCompletedCircle: {
     borderColor: Colors.dark.completed,
+    borderWidth: 2,
   },
   dayNumber: {
     fontSize: 16,

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build-dev": "npx eas build --profile development --platform android",
     "build-preview": "npx eas build --profile preview --platform android",
     "build": "npx eas build --profile production --platform android",
+    "update": "eas update --channel production",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",

--- a/utils/restNotification.ts
+++ b/utils/restNotification.ts
@@ -3,7 +3,6 @@ import { Platform } from "react-native";
 
 /**
  * Schedules a local notification to fire in `secondsFromNow`.
- * Cancels any existing notifications before scheduling the new one.
  * @param secondsFromNow how many seconds in the future the notification should fire
  * @param title notification title
  * @param body notification body
@@ -21,9 +20,6 @@ export async function scheduleRestNotification(
   }
 
   try {
-    // Cancel any existing notifications first
-    await Notifications.cancelAllScheduledNotificationsAsync();
-
     // Schedule the new notification
     await Notifications.scheduleNotificationAsync({
       content: {

--- a/utils/restNotification.ts
+++ b/utils/restNotification.ts
@@ -1,4 +1,5 @@
 import * as Notifications from "expo-notifications";
+import { Platform } from "react-native";
 
 /**
  * Schedules a local notification to fire in `secondsFromNow`.
@@ -22,7 +23,6 @@ export async function scheduleRestNotification(
   try {
     // Cancel any existing notifications first
     await Notifications.cancelAllScheduledNotificationsAsync();
-    await Notifications.dismissAllNotificationsAsync(); // This removes notifications from the notification drawer
 
     // Schedule the new notification
     await Notifications.scheduleNotificationAsync({
@@ -33,8 +33,10 @@ export async function scheduleRestNotification(
         // sound: "boxing_bell.mp3",
       },
       trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
         seconds: secondsFromNow,
-        channelId, // important on Android to match the channel created
+        repeats: false,
+        ...(Platform.OS === "android" && { channelId }),
       },
     });
   } catch (error) {

--- a/utils/restNotification.ts
+++ b/utils/restNotification.ts
@@ -48,3 +48,24 @@ export async function cancelRestNotifications() {
     console.error("Failed to cancel notifications:", error);
   }
 }
+
+/**
+ * Cancels any existing rest notifications and schedules a new one.
+ * This wrapper ensures the cancel-then-schedule contract is always enforced.
+ * @param secondsFromNow how many seconds in the future the notification should fire
+ * @param title notification title
+ * @param body notification body
+ * @param channelId must match the channel you created (on Android)
+ */
+export async function scheduleRestNotificationWithCancellation(
+  secondsFromNow: number,
+  title: string,
+  body: string,
+  channelId: string = "rest-timer1",
+) {
+  await cancelRestNotifications();
+
+  if (secondsFromNow > 0) {
+    await scheduleRestNotification(secondsFromNow, title, body, channelId);
+  }
+}


### PR DESCRIPTION
## Summary by Sourcery

Fix rest timer notifications firing too early and refine related UI and tooling.

Bug Fixes:
- Ensure rest timer notifications are cancelled before scheduling new ones to prevent early or duplicate alerts.
- Configure rest notification scheduling with explicit time-interval triggers and non-repeating behavior for more reliable timing.

Enhancements:
- Allow long workout exercise names in history details to wrap within the available space.
- Visually emphasize completed workout days by adding a border to the completion indicator circle.

Build:
- Add an npm script to trigger EAS updates on the production channel.