### PR TITLE
feat: add workout reordering functionality in CreatePlanScreen and WorkoutCard

### DIFF
--- a/app/(app)/(create-plan)/create.tsx
+++ b/app/(app)/(create-plan)/create.tsx
@@ -52,6 +52,7 @@ export default function CreatePlanScreen() {
     clearWorkouts,
     addWorkout,
     removeWorkout,
+    reorderWorkouts,
     changeWorkoutName,
   } = useWorkoutStore();
   const { planName, setPlanName, planSaved, setPlanSaved, handleSavePlan } =
@@ -262,7 +263,11 @@ export default function CreatePlanScreen() {
                   key={index}
                   workout={workout}
                   index={index}
+                  isFirst={index === 0}
+                  isLast={index === workouts.length - 1}
                   onRemove={() => handleRemoveWorkout(index)}
+                  onMoveUp={() => reorderWorkouts(index, index - 1)}
+                  onMoveDown={() => reorderWorkouts(index, index + 1)}
                   onNameChange={changeWorkoutName}
                   onAddExercise={() => handleAddExercise(index)}
                 />

--- a/app/(app)/(create-plan)/create.tsx
+++ b/app/(app)/(create-plan)/create.tsx
@@ -120,7 +120,7 @@ export default function CreatePlanScreen() {
   ]);
 
   const handleAddWorkout = () => {
-    const newWorkout = { name: "", exercises: [] };
+    const newWorkout = { name: "", exercises: [], id: -Date.now() };
     addWorkout(newWorkout);
 
     setTimeout(() => {
@@ -260,7 +260,7 @@ export default function CreatePlanScreen() {
             ) : (
               workouts.map((workout, index) => (
                 <WorkoutCard
-                  key={index}
+                  key={workout.id ?? index}
                   workout={workout}
                   index={index}
                   isFirst={index === 0}

--- a/app/(app)/(workout)/index.tsx
+++ b/app/(app)/(workout)/index.tsx
@@ -46,7 +46,8 @@ export default function WorkoutOverviewScreen() {
   const { data: completedWorkouts, error: completedWorkoutsError } =
     useCompletedWorkoutsQuery(weightUnit);
   const currentWorkoutHistory = completedWorkouts?.filter(
-    (completedWorkout) => completedWorkout.workout_name === activeWorkout?.name,
+    (completedWorkout) =>
+      completedWorkout.workout_id === activeWorkout?.workoutId,
   );
   const saveCompletedWorkoutMutation =
     useSaveCompletedWorkoutMutation(weightUnit);

--- a/components/WorkoutCard.tsx
+++ b/components/WorkoutCard.tsx
@@ -19,7 +19,11 @@ import { formatFromTotalSeconds } from "@/utils/utility";
 interface WorkoutCardProps {
   workout: Workout;
   index: number;
+  isFirst: boolean;
+  isLast: boolean;
   onRemove: (index: number) => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
   onNameChange: (index: number, name: string) => void;
   onAddExercise: (index: number) => void;
 }
@@ -27,7 +31,11 @@ interface WorkoutCardProps {
 export default function WorkoutCard({
   workout,
   index,
+  isFirst,
+  isLast,
   onRemove,
+  onMoveUp,
+  onMoveDown,
   onNameChange,
   onAddExercise,
 }: WorkoutCardProps) {
@@ -213,13 +221,27 @@ export default function WorkoutCard({
     <Card style={styles.workoutCard}>
       <View style={styles.workoutHeader}>
         <ThemedText style={styles.workoutDay}>Day {index + 1}</ThemedText>
-        <MaterialCommunityIcons
-          name="close"
-          onPress={() => onRemove(index)}
-          size={24}
-          color={Colors.dark.text}
-          style={styles.removeWorkoutButton}
-        />
+        <View style={styles.workoutHeaderActions}>
+          <MaterialCommunityIcons
+            name="chevron-up"
+            onPress={isFirst ? undefined : onMoveUp}
+            size={24}
+            color={isFirst ? Colors.dark.subText : Colors.dark.text}
+          />
+          <MaterialCommunityIcons
+            name="chevron-down"
+            onPress={isLast ? undefined : onMoveDown}
+            size={24}
+            color={isLast ? Colors.dark.subText : Colors.dark.text}
+          />
+          <MaterialCommunityIcons
+            name="close"
+            onPress={() => onRemove(index)}
+            size={24}
+            color={Colors.dark.text}
+            style={styles.removeWorkoutButton}
+          />
+        </View>
       </View>
       <TextInput
         placeholder="Workout name"
@@ -300,6 +322,10 @@ const styles = StyleSheet.create({
   workoutHeader: {
     flexDirection: "row",
     justifyContent: "space-between",
+    alignItems: "center",
+  },
+  workoutHeaderActions: {
+    flexDirection: "row",
     alignItems: "center",
   },
   workoutDay: {

--- a/store/workoutStore.ts
+++ b/store/workoutStore.ts
@@ -35,6 +35,7 @@ interface WorkoutStore {
   clearWorkouts: () => void;
   addWorkout: (workout: Workout) => void;
   removeWorkout: (index: number) => void;
+  reorderWorkouts: (fromIndex: number, toIndex: number) => void;
   changeWorkoutName: (index: number, name: string) => void;
   addExercise: (index: number, exercise: UserExercise) => void;
   removeExercise: (
@@ -82,6 +83,13 @@ const useWorkoutStore = create<WorkoutStore>((set) => ({
       ...state,
       workouts: state.workouts.filter((_, i) => i !== index),
     })),
+  reorderWorkouts: (fromIndex, toIndex) =>
+    set((state) => {
+      const updated = [...state.workouts];
+      const [moved] = updated.splice(fromIndex, 1);
+      updated.splice(toIndex, 0, moved);
+      return { ...state, workouts: updated };
+    }),
   changeWorkoutName: (index, name) =>
     set((state) => ({
       ...state,

--- a/store/workoutStore.ts
+++ b/store/workoutStore.ts
@@ -85,6 +85,16 @@ const useWorkoutStore = create<WorkoutStore>((set) => ({
     })),
   reorderWorkouts: (fromIndex, toIndex) =>
     set((state) => {
+      const { length } = state.workouts;
+      if (
+        fromIndex === toIndex ||
+        fromIndex < 0 ||
+        fromIndex >= length ||
+        toIndex < 0 ||
+        toIndex >= length
+      ) {
+        return state;
+      }
       const updated = [...state.workouts];
       const [moved] = updated.splice(fromIndex, 1);
       updated.splice(toIndex, 0, moved);


### PR DESCRIPTION
## Summary by Sourcery

Add workout reordering controls to the create plan flow and align workout history lookup with workout IDs.

New Features:
- Allow reordering of workouts in the CreatePlanScreen via up/down controls on each WorkoutCard.

Bug Fixes:
- Match completed workout history to the active workout using workout IDs instead of names.

Enhancements:
- Extend the workout store with a generic workout reordering helper used by the create plan UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Users can now reorder workouts within a training plan using up/down arrow controls
- Move buttons are intelligently disabled for the first and last items to prevent invalid operations

**Bug Fixes**
- Fixed workout history filtering to correctly match workout records using improved identifiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->