### PR TITLE
fix: workout details from home opening inside plans tab

### DIFF
--- a/app/(app)/(tabs)/(plans)/_layout.tsx
+++ b/app/(app)/(tabs)/(plans)/_layout.tsx
@@ -13,10 +13,6 @@ export default function PlansLayout() {
     >
       <Stack.Screen name="index" options={{ title: "Plans" }} />
       <Stack.Screen name="overview" options={{ title: "Plan Overview" }} />
-      <Stack.Screen
-        name="workout-details"
-        options={{ title: "Workout Details" }}
-      />
     </Stack>
   );
 }

--- a/app/(app)/(tabs)/(plans)/overview.tsx
+++ b/app/(app)/(tabs)/(plans)/overview.tsx
@@ -145,9 +145,13 @@ export default function PlanOverviewScreen() {
           <TouchableOpacity
             key={index.toString()}
             onPress={() =>
-              router.push(
-                `/workout-details?planId=${planId}&workoutIndex=${index}`,
-              )
+              router.push({
+                pathname: "/workout-details",
+                params: {
+                  planId: String(planId),
+                  workoutIndex: String(index),
+                },
+              })
             }
             style={styles.workoutCard}
           >

--- a/app/(app)/(tabs)/(plans)/workout-details.tsx
+++ b/app/(app)/(tabs)/(plans)/workout-details.tsx
@@ -1,1 +1,0 @@
-export { default } from "@/components/WorkoutDetailsScreen";


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure workouts opened from the plans overview navigate to the shared workout details route instead of an in-tab screen.