### PR TITLE
feat: add exercise details button to SetsOverviewScreen and WorkoutCard

### DIFF
--- a/app/(app)/(create-plan)/sets-overview.tsx
+++ b/app/(app)/(create-plan)/sets-overview.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
-import { StyleSheet, FlatList, TouchableOpacity } from "react-native";
+import { StyleSheet, FlatList, TouchableOpacity, View } from "react-native";
 import { Button } from "react-native-paper";
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
-import { Stack, useLocalSearchParams } from "expo-router";
+import { router, Stack, useLocalSearchParams } from "expo-router";
 import { useWorkoutStore, Set } from "@/store/workoutStore";
 import { Colors } from "@/constants/Colors";
 import { useSettingsQuery } from "@/hooks/useSettingsQuery";
@@ -108,13 +108,26 @@ export default function SetsOverviewScreen() {
         keyExtractor={(_: any, index: number) => index.toString()}
         contentContainerStyle={styles.flatListContent}
       />
-      <Button
-        mode="contained"
-        labelStyle={styles.buttonLabel}
-        onPress={handleAddSet}
-      >
-        Add Set
-      </Button>
+      <View style={styles.buttonRow}>
+        <Button
+          mode="outlined"
+          labelStyle={styles.buttonLabel}
+          style={styles.detailsButton}
+          onPress={() =>
+            router.push(`/(app)/exercise-details?exercise_id=${exerciseId}`)
+          }
+        >
+          Details
+        </Button>
+        <Button
+          mode="contained"
+          labelStyle={styles.buttonLabel}
+          style={styles.addSetButton}
+          onPress={handleAddSet}
+        >
+          Add Set
+        </Button>
+      </View>
       <EditSetModal
         visible={modalVisible}
         onClose={() => setModalVisible(false)}
@@ -167,6 +180,16 @@ const styles = StyleSheet.create({
   },
   flatListContent: {
     paddingBottom: 50,
+  },
+  buttonRow: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  detailsButton: {
+    flex: 1,
+  },
+  addSetButton: {
+    flex: 5,
   },
   buttonLabel: {
     fontSize: 16,

--- a/components/WorkoutCard.tsx
+++ b/components/WorkoutCard.tsx
@@ -194,6 +194,15 @@ export default function WorkoutCard({
                 }}
                 title="Replace"
               />
+              <Menu.Item
+                onPress={() => {
+                  closeMenu();
+                  router.push(
+                    `/(app)/exercise-details?exercise_id=${item.exercise_id}`,
+                  );
+                }}
+                title="View Details"
+              />
             </Menu>
           </TouchableOpacity>
         </Sortable.Pressable>


### PR DESCRIPTION
…ercise details navigation

## Summary by Sourcery

Add navigation entry points to the exercise details screen from both the sets overview screen and workout card menu.

New Features:
- Add a Details button alongside Add Set on the SetsOverviewScreen to open the exercise details screen for the current exercise.
- Add a View Details menu item to WorkoutCard to navigate to the exercise details screen for a selected exercise.