### PR TITLE
feat: include bugsnag sourcemaps with eas updates

### DIFF
--- a/app/(app)/(workout)/workout-summary.tsx
+++ b/app/(app)/(workout)/workout-summary.tsx
@@ -232,11 +232,10 @@ function DiffChip({
 }) {
   const isNeutral = diff === 0 || neutral;
   const isPositive = diff > 0;
-  const color = isNeutral
-    ? Colors.dark.subText
-    : isPositive === higherIsBetter
+  const color =
+    !isNeutral && isPositive === higherIsBetter
       ? Colors.dark.completed
-      : Colors.dark.highlight;
+      : Colors.dark.subText;
 
   const sign = diff > 0 ? "+" : "";
   const displayVal = Number.isInteger(diff)

--- a/app/(app)/(workout)/workout-summary.tsx
+++ b/app/(app)/(workout)/workout-summary.tsx
@@ -503,7 +503,7 @@ export default function WorkoutSummaryScreen() {
         {prevWorkout && (
           <View style={styles.progressionCard}>
             <ThemedText style={styles.progressionTitle}>
-              vs. Previous Session
+              vs. last &ldquo;{workout.workout_name}&rdquo;
             </ThemedText>
             <View style={styles.diffRow}>
               <DiffChip

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -56,8 +56,20 @@ import { setupNotificationChannel } from "@/utils/notificationSetup";
 import { setupAppCheck } from "@/utils/initAppCheck";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
+const manifest = Updates.manifest as
+  | (Updates.Manifest & {
+      metadata?: { updateGroup?: string };
+    })
+  | null;
+
+const codeBundleId =
+  manifest?.metadata?.updateGroup ?? Updates.updateId ?? undefined;
+
 // Initialize Bugsnag
-Bugsnag.start(process.env.EXPO_PUBLIC_BUGSNAG_API_KEY);
+Bugsnag.start({
+  apiKey: process.env.EXPO_PUBLIC_BUGSNAG_API_KEY,
+  codeBundleId,
+});
 
 const ErrorBoundary = Bugsnag.getPlugin("react").createErrorBoundary(React);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@shopify/flash-list": "2.0.2",
         "@tanstack/react-query": "^5.51.21",
         "date-fns": "^3.6.0",
+        "dotenv": "^17.4.2",
         "expo": "^54.0.0",
         "expo-application": "~7.0.8",
         "expo-asset": "~12.0.13",
@@ -8894,6 +8895,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@shopify/flash-list": "2.0.2",
     "@tanstack/react-query": "^5.51.21",
     "date-fns": "^3.6.0",
+    "dotenv": "^17.4.2",
     "expo": "^54.0.0",
     "expo-application": "~7.0.8",
     "expo-asset": "~12.0.13",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build-dev": "eas build --profile development --platform android",
     "build-preview": "eas build --profile preview --platform android",
     "build": "eas build --profile production --platform android",
-    "update": "eas update --channel production --platform android",
+    "update": "EAS_UPDATE_CHANNEL=production node scripts/bugsnag-eas-update-upload.js",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",

--- a/scripts/bugsnag-eas-update-upload.js
+++ b/scripts/bugsnag-eas-update-upload.js
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
+require("dotenv").config();
+
 const { promisify } = require("util");
 const { execFile } = require("child_process");
 const fs = require("fs").promises;
 const path = require("path");
 const readline = require("readline");
 const { reactNative } = require("@bugsnag/source-maps");
-const { getConfig } = require("@expo/config");
 
 const execFileAsync = promisify(execFile);
 const PROJECT_ROOT = process.cwd();
@@ -161,12 +162,13 @@ async function run() {
   await fs.copyFile(originalBundle, bundle);
   await fs.copyFile(originalSourceMap, sourceMap);
 
-  // 5) Read Bugsnag API key from Expo config
-  const appConfig = getConfig(PROJECT_ROOT);
-  const apiKey = appConfig?.exp?.extra?.bugsnag?.apiKey;
+  // 5) Read Bugsnag API key from .env and upload to Bugsnag
+  const apiKey = process.env.EXPO_PUBLIC_BUGSNAG_API_KEY;
 
   if (!apiKey) {
-    throw new Error("No Bugsnag API key found in expo.extra.bugsnag.apiKey.");
+    throw new Error(
+      "No Bugsnag API key found. Set EXPO_PUBLIC_BUGSNAG_API_KEY in your .env.",
+    );
   }
 
   console.log("3) Uploading Android EAS Update sourcemap to Bugsnag...\n");

--- a/scripts/bugsnag-eas-update-upload.js
+++ b/scripts/bugsnag-eas-update-upload.js
@@ -50,7 +50,6 @@ async function run() {
       "--dump-sourcemap",
       "--output-dir",
       "dist",
-      "--non-interactive",
     ],
     {
       cwd: PROJECT_ROOT,
@@ -123,22 +122,29 @@ async function run() {
 
   console.log(`\nUsing codeBundleId: ${codeBundleId}\n`);
 
-  // 3) Find Android bundle + sourcemap in dist/bundles
-  const bundlesDir = path.join(PROJECT_ROOT, "dist", "bundles");
+  // 3) Find Android bundle + sourcemap in dist/_expo/static/js/android
+  const bundlesDir = path.join(
+    PROJECT_ROOT,
+    "dist",
+    "_expo",
+    "static",
+    "js",
+    "android",
+  );
   const entries = await fs.readdir(bundlesDir).catch((err) => {
     throw new Error(
       `Could not read ${bundlesDir}. Did expo export run successfully?\n${err}`,
     );
   });
 
-  const androidBundleFile = entries.find((f) =>
-    /^android-.*\.(hbc|js)$/.test(f),
+  const androidBundleFile = entries.find((f) => /^entry-.*\.(hbc|js)$/.test(f));
+  const androidSourceMapFile = entries.find((f) =>
+    /^entry-.*\.hbc\.map$/.test(f),
   );
-  const androidSourceMapFile = entries.find((f) => /^android-.*\.map$/.test(f));
 
   if (!androidBundleFile || !androidSourceMapFile) {
     throw new Error(
-      `Could not find android-*.hbc/js or android-*.map in ${bundlesDir}.`,
+      `Could not find entry-*.hbc/js or entry-*.hbc.map in ${bundlesDir}.`,
     );
   }
 
@@ -154,10 +160,6 @@ async function run() {
 
   await fs.copyFile(originalBundle, bundle);
   await fs.copyFile(originalSourceMap, sourceMap);
-
-  console.log("Bundle and sourcemap prepared:");
-  console.log(`  bundle:    ${bundle}`);
-  console.log(`  sourcemap: ${sourceMap}\n`);
 
   // 5) Read Bugsnag API key from Expo config
   const appConfig = getConfig(PROJECT_ROOT);

--- a/scripts/bugsnag-eas-update-upload.js
+++ b/scripts/bugsnag-eas-update-upload.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+const { promisify } = require("util");
+const { execFile } = require("child_process");
+const fs = require("fs").promises;
+const path = require("path");
+const { reactNative } = require("@bugsnag/source-maps");
+const { getConfig } = require("@expo/config");
+
+const execFileAsync = promisify(execFile);
+const PROJECT_ROOT = process.cwd();
+
+// Default channel; override with EAS_UPDATE_CHANNEL=staging etc.
+const CHANNEL = process.env.EAS_UPDATE_CHANNEL || "production";
+
+async function run() {
+  console.log(`Running EAS Update on channel "${CHANNEL}" for Android...`);
+
+  // 1) Run eas update and capture JSON output (array of updates)
+  const { stdout } = await execFileAsync(
+    "eas",
+    [
+      "update",
+      "--channel",
+      CHANNEL,
+      "--platform",
+      "android",
+      "--non-interactive",
+      "--auto",
+      "--json",
+    ],
+    {
+      cwd: PROJECT_ROOT,
+      maxBuffer: 10 * 1024 * 1024,
+    },
+  );
+
+  const updates = JSON.parse(stdout);
+  const androidUpdate =
+    Array.isArray(updates) && updates.find((u) => u.platform === "android");
+
+  if (!androidUpdate) {
+    throw new Error(
+      "No Android update found in EAS update JSON output. Check that eas update ran successfully.",
+    );
+  }
+
+  // Prefer group (update group ID) to match manifest.metadata.updateGroup
+  const codeBundleId =
+    androidUpdate.group || androidUpdate.groupId || androidUpdate.id;
+
+  if (!codeBundleId) {
+    throw new Error(
+      "Could not determine codeBundleId from EAS update output (no group/groupId/id).",
+    );
+  }
+
+  console.log(`Using codeBundleId: ${codeBundleId}`);
+
+  // 2) Find Android bundle + sourcemap in dist/bundles
+  const bundlesDir = path.join(PROJECT_ROOT, "dist", "bundles");
+  const entries = await fs.readdir(bundlesDir);
+
+  const bundleFile = entries.find((f) => /^android-.*\.js$/.test(f));
+  const sourceMapFile = entries.find((f) => /^android-.*\.map$/.test(f));
+
+  if (!bundleFile || !sourceMapFile) {
+    throw new Error(
+      `Could not find android-*.js / android-*.map in ${bundlesDir}. ` +
+        "Confirm that EAS Update produced bundles there.",
+    );
+  }
+
+  const bundle = path.join(bundlesDir, bundleFile);
+  const sourceMap = path.join(bundlesDir, sourceMapFile);
+
+  console.log("Found bundle and sourcemap:");
+  console.log(`  bundle:    ${bundle}`);
+  console.log(`  sourcemap: ${sourceMap}`);
+
+  // 3) Read Bugsnag API key from Expo config
+  const appConfig = getConfig(PROJECT_ROOT);
+  const apiKey = appConfig?.exp?.extra?.bugsnag?.apiKey;
+
+  if (!apiKey) {
+    throw new Error("No Bugsnag API key found in expo.extra.bugsnag.apiKey.");
+  }
+
+  console.log("Uploading Android EAS Update sourcemap to Bugsnag...");
+
+  await reactNative.uploadOne({
+    apiKey,
+    platform: "android",
+    bundle,
+    sourceMap,
+    projectRoot: PROJECT_ROOT,
+    codeBundleId, // must match Bugsnag.start({ codeBundleId: ... })
+  });
+
+  console.log("Successfully uploaded Android EAS Update sourcemap to Bugsnag.");
+}
+
+run().catch((err) => {
+  console.error("Error during EAS Update + Bugsnag upload:");
+  console.error(err?.stack || err);
+  process.exit(1);
+});

--- a/scripts/bugsnag-eas-update-upload.js
+++ b/scripts/bugsnag-eas-update-upload.js
@@ -140,12 +140,12 @@ async function run() {
 
   const androidBundleFile = entries.find((f) => /^entry-.*\.(hbc|js)$/.test(f));
   const androidSourceMapFile = entries.find((f) =>
-    /^entry-.*\.hbc\.map$/.test(f),
+    /^entry-.*\.(hbc|js)\.map$/.test(f),
   );
 
   if (!androidBundleFile || !androidSourceMapFile) {
     throw new Error(
-      `Could not find entry-*.hbc/js or entry-*.hbc.map in ${bundlesDir}.`,
+      `Could not find entry-*.hbc/js or entry-*.hbc.map/entry-*.js.map in ${bundlesDir}.`,
     );
   }
 

--- a/scripts/bugsnag-eas-update-upload.js
+++ b/scripts/bugsnag-eas-update-upload.js
@@ -4,20 +4,71 @@ const { promisify } = require("util");
 const { execFile } = require("child_process");
 const fs = require("fs").promises;
 const path = require("path");
+const readline = require("readline");
 const { reactNative } = require("@bugsnag/source-maps");
 const { getConfig } = require("@expo/config");
 
 const execFileAsync = promisify(execFile);
 const PROJECT_ROOT = process.cwd();
-
-// Default channel; override with EAS_UPDATE_CHANNEL=staging etc.
 const CHANNEL = process.env.EAS_UPDATE_CHANNEL || "production";
 
-async function run() {
-  console.log(`Running EAS Update on channel "${CHANNEL}" for Android...`);
+function ask(question) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
 
-  // 1) Run eas update and capture JSON output (array of updates)
-  const { stdout } = await execFileAsync(
+async function run() {
+  console.log(`Preparing EAS Update for channel "${CHANNEL}" (Android)...`);
+
+  // 0) Ask for update message
+  const defaultMessage = "OTA update";
+  const msgInput = await ask(
+    `EAS update message [default: "${defaultMessage}"]: `,
+  );
+  const message = (msgInput && msgInput.trim()) || defaultMessage;
+
+  console.log(
+    "\n1) Exporting bundles + sourcemaps for Android (expo export)...\n",
+  );
+
+  // 1) Create a local export with sourcemaps
+  const exportResult = await execFileAsync(
+    "npx",
+    [
+      "expo",
+      "export",
+      "--platform",
+      "android",
+      "--dump-sourcemap",
+      "--output-dir",
+      "dist",
+      "--non-interactive",
+    ],
+    {
+      cwd: PROJECT_ROOT,
+      maxBuffer: 10 * 1024 * 1024,
+    },
+  );
+
+  if (exportResult.stdout) {
+    process.stdout.write(exportResult.stdout);
+  }
+  if (exportResult.stderr) {
+    process.stderr.write(exportResult.stderr);
+  }
+
+  console.log("\n2) Running EAS Update for Android...\n");
+
+  // 2) Run eas update and capture JSON output
+  const updateResult = await execFileAsync(
     "eas",
     [
       "update",
@@ -26,8 +77,9 @@ async function run() {
       "--platform",
       "android",
       "--non-interactive",
-      "--auto",
       "--json",
+      "--message",
+      message,
     ],
     {
       cwd: PROJECT_ROOT,
@@ -35,7 +87,22 @@ async function run() {
     },
   );
 
-  const updates = JSON.parse(stdout);
+  if (updateResult.stdout) {
+    process.stdout.write(updateResult.stdout);
+  }
+  if (updateResult.stderr) {
+    process.stderr.write(updateResult.stderr);
+  }
+
+  let updates;
+  try {
+    updates = JSON.parse(updateResult.stdout);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse EAS Update JSON output. Did --json run correctly?\n${err}`,
+    );
+  }
+
   const androidUpdate =
     Array.isArray(updates) && updates.find((u) => u.platform === "android");
 
@@ -45,7 +112,6 @@ async function run() {
     );
   }
 
-  // Prefer group (update group ID) to match manifest.metadata.updateGroup
   const codeBundleId =
     androidUpdate.group || androidUpdate.groupId || androidUpdate.id;
 
@@ -55,30 +121,45 @@ async function run() {
     );
   }
 
-  console.log(`Using codeBundleId: ${codeBundleId}`);
+  console.log(`\nUsing codeBundleId: ${codeBundleId}\n`);
 
-  // 2) Find Android bundle + sourcemap in dist/bundles
+  // 3) Find Android bundle + sourcemap in dist/bundles
   const bundlesDir = path.join(PROJECT_ROOT, "dist", "bundles");
-  const entries = await fs.readdir(bundlesDir);
-
-  const bundleFile = entries.find((f) => /^android-.*\.js$/.test(f));
-  const sourceMapFile = entries.find((f) => /^android-.*\.map$/.test(f));
-
-  if (!bundleFile || !sourceMapFile) {
+  const entries = await fs.readdir(bundlesDir).catch((err) => {
     throw new Error(
-      `Could not find android-*.js / android-*.map in ${bundlesDir}. ` +
-        "Confirm that EAS Update produced bundles there.",
+      `Could not read ${bundlesDir}. Did expo export run successfully?\n${err}`,
+    );
+  });
+
+  const androidBundleFile = entries.find((f) =>
+    /^android-.*\.(hbc|js)$/.test(f),
+  );
+  const androidSourceMapFile = entries.find((f) => /^android-.*\.map$/.test(f));
+
+  if (!androidBundleFile || !androidSourceMapFile) {
+    throw new Error(
+      `Could not find android-*.hbc/js or android-*.map in ${bundlesDir}.`,
     );
   }
 
-  const bundle = path.join(bundlesDir, bundleFile);
-  const sourceMap = path.join(bundlesDir, sourceMapFile);
+  const originalBundle = path.join(bundlesDir, androidBundleFile);
+  const originalSourceMap = path.join(bundlesDir, androidSourceMapFile);
 
-  console.log("Found bundle and sourcemap:");
+  // 4) Copy to the names Bugsnag expects
+  const bugSnagDir = path.join(PROJECT_ROOT, "dist", "bugsnag-android");
+  await fs.mkdir(bugSnagDir, { recursive: true });
+
+  const bundle = path.join(bugSnagDir, "index.android.bundle");
+  const sourceMap = path.join(bugSnagDir, "index.android.bundle.map");
+
+  await fs.copyFile(originalBundle, bundle);
+  await fs.copyFile(originalSourceMap, sourceMap);
+
+  console.log("Bundle and sourcemap prepared:");
   console.log(`  bundle:    ${bundle}`);
-  console.log(`  sourcemap: ${sourceMap}`);
+  console.log(`  sourcemap: ${sourceMap}\n`);
 
-  // 3) Read Bugsnag API key from Expo config
+  // 5) Read Bugsnag API key from Expo config
   const appConfig = getConfig(PROJECT_ROOT);
   const apiKey = appConfig?.exp?.extra?.bugsnag?.apiKey;
 
@@ -86,7 +167,7 @@ async function run() {
     throw new Error("No Bugsnag API key found in expo.extra.bugsnag.apiKey.");
   }
 
-  console.log("Uploading Android EAS Update sourcemap to Bugsnag...");
+  console.log("3) Uploading Android EAS Update sourcemap to Bugsnag...\n");
 
   await reactNative.uploadOne({
     apiKey,
@@ -94,10 +175,12 @@ async function run() {
     bundle,
     sourceMap,
     projectRoot: PROJECT_ROOT,
-    codeBundleId, // must match Bugsnag.start({ codeBundleId: ... })
+    codeBundleId,
   });
 
-  console.log("Successfully uploaded Android EAS Update sourcemap to Bugsnag.");
+  console.log(
+    "✅ Successfully uploaded Android EAS Update sourcemap to Bugsnag.\n",
+  );
 }
 
 run().catch((err) => {


### PR DESCRIPTION
## Summary by Sourcery

Integrate Bugsnag sourcemap support for Android EAS updates and adjust workout summary diff styling.

New Features:
- Add EAS update script that exports Android bundles, runs EAS update, and uploads corresponding sourcemaps to Bugsnag using the update group as codeBundleId.
- Propagate EAS update group/update ID into the app and configure Bugsnag with a matching codeBundleId for error reporting.

Enhancements:
- Adjust workout summary diff chip coloring so only non-neutral, directionally meaningful diffs use the highlighted color and others use the subtler text color.

Build:
- Replace the generic EAS Android update npm script with a custom script that runs EAS update and uploads Bugsnag sourcemaps, and add dotenv dependency for environment configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed colour display logic for workout summary diff values to improve visual consistency.

* **Chores**
  * Enhanced error reporting and tracking infrastructure for improved diagnostics.
  * Improved deployment automation and update process reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/isotronic/MuscleQuest/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->