### PR TITLE
feat: enhance exercise tracking with unilateral and double weight support

### DIFF
--- a/app/(app)/(tabs)/(stats)/exercise-detail.tsx
+++ b/app/(app)/(tabs)/(stats)/exercise-detail.tsx
@@ -21,6 +21,8 @@ export default function ExerciseDetailScreen() {
   const weightUnit = settings?.weightUnit || "kg";
   const distanceUnit = settings?.distanceUnit || "m";
   const excludeWarmup = settings?.excludeWarmupSets === "true";
+  const countUnilateralDouble = settings?.countUnilateralDouble === "true";
+  const doubleWeightForPaired = settings?.doubleWeightForPaired === "true";
   const [timeRange, setTimeRange] = useState("30");
 
   useEffect(() => {
@@ -36,6 +38,8 @@ export default function ExerciseDetailScreen() {
     timeRange,
     weightUnit,
     excludeWarmup,
+    countUnilateralDouble,
+    doubleWeightForPaired,
   );
 
   const convFactor = weightUnit === "lbs" ? 2.2046226 : 1;

--- a/app/(app)/(tabs)/(stats)/index.tsx
+++ b/app/(app)/(tabs)/(stats)/index.tsx
@@ -31,6 +31,8 @@ const computeStats = (
   workouts: CompletedWorkout[],
   weightUnit: string,
   excludeWarmup: boolean,
+  countUnilateralDouble: boolean = false,
+  doubleWeightForPaired: boolean = false,
 ) => {
   const tonDivisor = weightUnit === "lbs" ? 2000 : 1000;
   const totalWorkouts = workouts.length;
@@ -47,18 +49,20 @@ const computeStats = (
   const totalVolume = workouts.reduce(
     (acc, w) =>
       acc +
-      w.exercises.reduce(
-        (a, e) =>
+      w.exercises.reduce((a, e) => {
+        const weightM = doubleWeightForPaired && e.double_weight ? 2 : 1;
+        const repM = countUnilateralDouble && e.is_unilateral ? 2 : 1;
+        return (
           a +
           e.sets.reduce(
             (s, set) =>
               (!excludeWarmup || !set.is_warmup) && set.weight && set.reps
-                ? s + set.weight * set.reps
+                ? s + set.weight * weightM * set.reps * repM
                 : s,
             0,
-          ),
-        0,
-      ),
+          )
+        );
+      }, 0),
     0,
   );
   const totalTimeSeconds = workouts.reduce((acc, w) => acc + w.duration, 0);
@@ -79,6 +83,8 @@ export default function StatsScreen() {
   const weightUnit = settings?.weightUnit || "kg";
   const distanceUnit = settings?.distanceUnit || "m";
   const excludeWarmup = settings?.excludeWarmupSets === "true";
+  const countUnilateralDouble = settings?.countUnilateralDouble === "true";
+  const doubleWeightForPaired = settings?.doubleWeightForPaired === "true";
   const [selectedTimeRange, setSelectedTimeRange] = useState<string>(
     settings?.timeRange || "30",
   );
@@ -96,7 +102,12 @@ export default function StatsScreen() {
     data: trackedExercises,
     isLoading: isLoadingTracked,
     error: trackedError,
-  } = useTrackedExercisesQuery(selectedTimeRange, excludeWarmup);
+  } = useTrackedExercisesQuery(
+    selectedTimeRange,
+    excludeWarmup,
+    countUnilateralDouble,
+    doubleWeightForPaired,
+  );
   const {
     data: completedWorkouts,
     isLoading: isLoadingWorkouts,
@@ -194,9 +205,17 @@ export default function StatsScreen() {
     completedWorkouts ?? [],
     weightUnit,
     excludeWarmup,
+    countUnilateralDouble,
+    doubleWeightForPaired,
   );
   const prev = prevWorkouts
-    ? computeStats(prevWorkouts, weightUnit, excludeWarmup)
+    ? computeStats(
+        prevWorkouts,
+        weightUnit,
+        excludeWarmup,
+        countUnilateralDouble,
+        doubleWeightForPaired,
+      )
     : null;
 
   const volumeUnit = weightUnit === "lbs" ? "tn" : "t";
@@ -303,6 +322,8 @@ export default function StatsScreen() {
               timeRange={selectedTimeRange}
               weightUnit={weightUnit}
               excludeWarmup={excludeWarmup}
+              countUnilateralDouble={countUnilateralDouble}
+              doubleWeightForPaired={doubleWeightForPaired}
             />
           </View>
         )}

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -332,6 +332,8 @@ export default function HomeScreen() {
               weightUnit={settings?.weightUnit ?? "kg"}
               streak={streak}
               excludeWarmup={settings?.excludeWarmupSets === "true"}
+              countUnilateralDouble={settings?.countUnilateralDouble === "true"}
+              doubleWeightForPaired={settings?.doubleWeightForPaired === "true"}
             />
           </View>
         )}

--- a/app/(app)/(tabs)/settings.tsx
+++ b/app/(app)/(tabs)/settings.tsx
@@ -106,6 +106,8 @@ export default function SettingsScreen() {
     restTimerNotification: settings?.restTimerNotification,
     showOnboarding: settings?.showOnboarding,
     excludeWarmupSets: settings?.excludeWarmupSets,
+    countUnilateralDouble: settings?.countUnilateralDouble,
+    doubleWeightForPaired: settings?.doubleWeightForPaired,
   });
 
   const [workoutReminderEnabled, setWorkoutReminderEnabled] = useState(false);
@@ -134,6 +136,8 @@ export default function SettingsScreen() {
         restTimerNotification: settings?.restTimerNotification,
         showOnboarding: settings?.showOnboarding,
         excludeWarmupSets: settings?.excludeWarmupSets,
+        countUnilateralDouble: settings?.countUnilateralDouble,
+        doubleWeightForPaired: settings?.doubleWeightForPaired,
       });
       setWorkoutReminderEnabled(settings.workoutReminderEnabled === "true");
       try {
@@ -258,6 +262,22 @@ export default function SettingsScreen() {
   const toggleExcludeWarmupSets = (value: boolean) => {
     setToggleValues({ ...toggleValues, excludeWarmupSets: value.toString() });
     updateSetting({ key: "excludeWarmupSets", value: value.toString() });
+  };
+
+  const toggleCountUnilateralDouble = (value: boolean) => {
+    setToggleValues({
+      ...toggleValues,
+      countUnilateralDouble: value.toString(),
+    });
+    updateSetting({ key: "countUnilateralDouble", value: value.toString() });
+  };
+
+  const toggleDoubleWeightForPaired = (value: boolean) => {
+    setToggleValues({
+      ...toggleValues,
+      doubleWeightForPaired: value.toString(),
+    });
+    updateSetting({ key: "doubleWeightForPaired", value: value.toString() });
   };
 
   const toggleVibration = (value: boolean) => {
@@ -812,12 +832,62 @@ export default function SettingsScreen() {
                 Exclude warmup sets from stats
               </ThemedText>
               <ThemedText style={styles.currentSetting}>
-                {toggleValues.excludeWarmupSets === "true" ? "Enabled" : "Disabled"}
+                {toggleValues.excludeWarmupSets === "true"
+                  ? "Enabled"
+                  : "Disabled"}
               </ThemedText>
             </View>
             <Switch
               value={toggleValues.excludeWarmupSets === "true"}
               onValueChange={toggleExcludeWarmupSets}
+              color={Colors.dark.tint}
+              style={styles.switch}
+            />
+          </View>
+          <View style={styles.item}>
+            <MaterialCommunityIcons
+              name="arm-flex"
+              size={24}
+              color={Colors.dark.icon}
+              style={styles.icon}
+            />
+            <View style={styles.textContainer}>
+              <ThemedText style={styles.itemText}>
+                I log one side only for single-arm/leg exercises
+              </ThemedText>
+              <ThemedText style={styles.currentSetting}>
+                {toggleValues.countUnilateralDouble === "true"
+                  ? "Counting reps ×2 for these exercises"
+                  : "Disabled"}
+              </ThemedText>
+            </View>
+            <Switch
+              value={toggleValues.countUnilateralDouble === "true"}
+              onValueChange={toggleCountUnilateralDouble}
+              color={Colors.dark.tint}
+              style={styles.switch}
+            />
+          </View>
+          <View style={styles.item}>
+            <MaterialCommunityIcons
+              name="dumbbell"
+              size={24}
+              color={Colors.dark.icon}
+              style={styles.icon}
+            />
+            <View style={styles.textContainer}>
+              <ThemedText style={styles.itemText}>
+                I enter weight per dumbbell / cable, not total
+              </ThemedText>
+              <ThemedText style={styles.currentSetting}>
+                {toggleValues.doubleWeightForPaired === "true"
+                  ? "Doubling weight for volume calculations"
+                  : "Disabled"}
+              </ThemedText>
+            </View>
+            <Switch
+              value={toggleValues.doubleWeightForPaired === "true"}
+              onValueChange={toggleDoubleWeightForPaired}
               color={Colors.dark.tint}
               style={styles.switch}
             />

--- a/app/(app)/(workout)/workout-summary.tsx
+++ b/app/(app)/(workout)/workout-summary.tsx
@@ -147,18 +147,29 @@ function formatDuration(seconds: number): string {
   return `${s}s`;
 }
 
-function computeVolume(workout: CompletedWorkout, excludeWarmup: boolean = false): number {
-  return workout.exercises.reduce(
-    (total, exercise) =>
+function computeVolume(
+  workout: CompletedWorkout,
+  excludeWarmup: boolean = false,
+  countUnilateralDouble: boolean = false,
+  doubleWeightForPaired: boolean = false,
+): number {
+  return workout.exercises.reduce((total, exercise) => {
+    const weightM = doubleWeightForPaired && exercise.double_weight ? 2 : 1;
+    const repM = countUnilateralDouble && exercise.is_unilateral ? 2 : 1;
+    return (
       total +
       exercise.sets.reduce((setTotal, set) => {
-        if ((!excludeWarmup || !set.is_warmup) && set.weight != null && set.reps != null) {
-          return setTotal + set.weight * set.reps;
+        if (
+          (!excludeWarmup || !set.is_warmup) &&
+          set.weight != null &&
+          set.reps != null
+        ) {
+          return setTotal + set.weight * weightM * set.reps * repM;
         }
         return setTotal;
-      }, 0),
-    0,
-  );
+      }, 0)
+    );
+  }, 0);
 }
 
 function getBestSetLabel(
@@ -388,6 +399,8 @@ export default function WorkoutSummaryScreen() {
   const weightUnit = settings?.weightUnit ?? "kg";
   const distanceUnit = settings?.distanceUnit ?? "m";
   const excludeWarmup = settings?.excludeWarmupSets === "true";
+  const countUnilateralDouble = settings?.countUnilateralDouble === "true";
+  const doubleWeightForPaired = settings?.doubleWeightForPaired === "true";
 
   const id = Number(completedWorkoutId);
   const isValidId = Number.isFinite(id) && id > 0;
@@ -403,7 +416,10 @@ export default function WorkoutSummaryScreen() {
     weightUnit,
     distanceUnit,
   );
-  const { data: allWorkouts } = useCompletedWorkoutsQuery(weightUnit, distanceUnit);
+  const { data: allWorkouts } = useCompletedWorkoutsQuery(
+    weightUnit,
+    distanceUnit,
+  );
 
   const weeklyGoal = Number(settings?.weeklyGoal ?? 0);
 
@@ -428,17 +444,36 @@ export default function WorkoutSummaryScreen() {
   }, [history, workout]);
 
   const currentVolume = useMemo(
-    () => (workout ? computeVolume(workout, excludeWarmup) : 0),
-    [workout, excludeWarmup],
+    () =>
+      workout
+        ? computeVolume(
+            workout,
+            excludeWarmup,
+            countUnilateralDouble,
+            doubleWeightForPaired,
+          )
+        : 0,
+    [workout, excludeWarmup, countUnilateralDouble, doubleWeightForPaired],
   );
   const prevVolume = useMemo(
-    () => (prevWorkout ? computeVolume(prevWorkout, excludeWarmup) : 0),
-    [prevWorkout, excludeWarmup],
+    () =>
+      prevWorkout
+        ? computeVolume(
+            prevWorkout,
+            excludeWarmup,
+            countUnilateralDouble,
+            doubleWeightForPaired,
+          )
+        : 0,
+    [prevWorkout, excludeWarmup, countUnilateralDouble, doubleWeightForPaired],
   );
 
   const countSets = (w: CompletedWorkout) =>
     excludeWarmup
-      ? w.exercises.reduce((t, e) => t + e.sets.filter((s) => !s.is_warmup).length, 0)
+      ? w.exercises.reduce(
+          (t, e) => t + e.sets.filter((s) => !s.is_warmup).length,
+          0,
+        )
       : w.total_sets_completed;
 
   if (isLoading) {

--- a/app/(app)/custom-exercise.tsx
+++ b/app/(app)/custom-exercise.tsx
@@ -8,9 +8,8 @@ import {
   Platform,
   Image,
   View,
-  Switch,
 } from "react-native";
-import { Button, Divider } from "react-native-paper";
+import { Button, Divider, Switch } from "react-native-paper";
 import DropDownPicker from "react-native-dropdown-picker";
 import { ThemedText } from "@/components/ThemedText";
 import * as ImagePicker from "expo-image-picker";
@@ -595,7 +594,7 @@ export default function AddCustomExerciseScreen() {
                   setIsUnilateral(v);
                   markDirty();
                 }}
-                thumbColor={Colors.dark.tint}
+                color={Colors.dark.tint}
               />
             </View>
 
@@ -614,7 +613,7 @@ export default function AddCustomExerciseScreen() {
                   setDoubleWeight(v);
                   markDirty();
                 }}
-                thumbColor={Colors.dark.tint}
+                color={Colors.dark.tint}
               />
             </View>
           </View>

--- a/app/(app)/custom-exercise.tsx
+++ b/app/(app)/custom-exercise.tsx
@@ -8,6 +8,7 @@ import {
   Platform,
   Image,
   View,
+  Switch,
 } from "react-native";
 import { Button, Divider } from "react-native-paper";
 import DropDownPicker from "react-native-dropdown-picker";
@@ -54,6 +55,8 @@ export default function AddCustomExerciseScreen() {
   const [equipment, setEquipment] = useState<string>("");
   const [secondaryMuscles, setSecondaryMuscles] = useState<string[]>([]);
   const [trackingType, setTrackingType] = useState<string>("");
+  const [isUnilateral, setIsUnilateral] = useState(false);
+  const [doubleWeight, setDoubleWeight] = useState(false);
 
   const [errors, setErrors] = useState<Record<string, string>>({});
 
@@ -177,6 +180,8 @@ export default function AddCustomExerciseScreen() {
             setSecondaryMuscles([]);
           }
           setTrackingType(existingData.tracking_type ?? "");
+          setIsUnilateral(existingData.is_unilateral === 1);
+          setDoubleWeight(existingData.double_weight === 1);
         }
       } catch (error: any) {
         console.error("Error fetching exercise data for editing:", error);
@@ -241,7 +246,7 @@ export default function AddCustomExerciseScreen() {
 
       if (isEditing) {
         await db.runAsync(
-          `UPDATE exercises SET name = ?, description = ?, local_animated_uri = ?, body_part = ?, target_muscle = ?, equipment = ?, secondary_muscles = ? WHERE exercise_id = ?`,
+          `UPDATE exercises SET name = ?, description = ?, local_animated_uri = ?, body_part = ?, target_muscle = ?, equipment = ?, secondary_muscles = ?, is_unilateral = ?, double_weight = ? WHERE exercise_id = ?`,
           [
             name,
             JSON.stringify([description]),
@@ -250,12 +255,14 @@ export default function AddCustomExerciseScreen() {
             targetMuscle,
             equipment,
             JSON.stringify(secondaryMuscles),
+            isUnilateral ? 1 : 0,
+            doubleWeight ? 1 : 0,
             Number(exercise_id),
           ],
         );
       } else {
         await db.runAsync(
-          `INSERT INTO exercises (app_exercise_id, name, description, local_animated_uri, body_part, target_muscle, equipment, secondary_muscles, tracking_type) VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          `INSERT INTO exercises (app_exercise_id, name, description, local_animated_uri, body_part, target_muscle, equipment, secondary_muscles, tracking_type, is_unilateral, double_weight) VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
           [
             name,
             JSON.stringify([description]),
@@ -265,6 +272,8 @@ export default function AddCustomExerciseScreen() {
             equipment,
             JSON.stringify(secondaryMuscles),
             trackingType,
+            isUnilateral ? 1 : 0,
+            doubleWeight ? 1 : 0,
           ],
         );
 
@@ -565,6 +574,51 @@ export default function AddCustomExerciseScreen() {
             </View>
           </View>
 
+          <Divider style={styles.divider} />
+
+          {/* ── Stats Options ──────────────────────────────── */}
+          <View style={styles.section}>
+            <ThemedText style={styles.sectionHeader}>Stats Options</ThemedText>
+
+            <View style={styles.switchRow}>
+              <View style={styles.switchTextContainer}>
+                <ThemedText style={styles.fieldLabel}>
+                  Single-arm / single-leg
+                </ThemedText>
+                <ThemedText style={styles.helperText}>
+                  Count reps ×2 for volume when the setting is enabled
+                </ThemedText>
+              </View>
+              <Switch
+                value={isUnilateral}
+                onValueChange={(v: boolean) => {
+                  setIsUnilateral(v);
+                  markDirty();
+                }}
+                thumbColor={Colors.dark.tint}
+              />
+            </View>
+
+            <View style={styles.switchRow}>
+              <View style={styles.switchTextContainer}>
+                <ThemedText style={styles.fieldLabel}>
+                  Paired implements
+                </ThemedText>
+                <ThemedText style={styles.helperText}>
+                  Double the weight for volume when the setting is enabled
+                </ThemedText>
+              </View>
+              <Switch
+                value={doubleWeight}
+                onValueChange={(v: boolean) => {
+                  setDoubleWeight(v);
+                  markDirty();
+                }}
+                thumbColor={Colors.dark.tint}
+              />
+            </View>
+          </View>
+
           <Button
             mode="contained"
             labelStyle={styles.buttonLabel}
@@ -659,5 +713,15 @@ const styles = StyleSheet.create({
   },
   buttonLabel: {
     fontSize: 16,
+  },
+  switchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 16,
+  },
+  switchTextContainer: {
+    flex: 1,
+    marginRight: 12,
   },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -41,6 +41,7 @@ import {
   copyDataFromAppDataToUserData,
   fetchSettings,
   insertDefaultSettings,
+  syncExerciseFlagsFromAppData,
   updateAppExerciseIds,
 } from "@/utils/database";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
@@ -135,6 +136,7 @@ function RootLayout() {
         await updateAppExerciseIds();
         await insertDefaultSettings();
         await loadPremadePlans();
+        await syncExerciseFlagsFromAppData();
         // Set the database initialization state to true after setup is complete
         setIsDatabaseInitialized(true);
       } catch (error) {

--- a/components/WeeklySummaryCard.tsx
+++ b/components/WeeklySummaryCard.tsx
@@ -14,6 +14,8 @@ interface Props {
   weightUnit: string;
   streak: number;
   excludeWarmup?: boolean;
+  countUnilateralDouble?: boolean;
+  doubleWeightForPaired?: boolean;
 }
 
 function formatDuration(seconds: number): string {
@@ -28,11 +30,14 @@ function getProgressionMetric(
   reps: number | null,
   time: number | null,
   trackingType: string,
+  weightM: number = 1,
+  repM: number = 1,
 ): number | null {
-  if (trackingType === "reps") return reps;
+  if (trackingType === "reps") return reps != null ? reps * repM : null;
   if (trackingType === "time") return time;
-  // weight, assisted, or null → Epley 1RM
-  if (weight != null && reps != null) return weight * (1 + reps / 30.0);
+  // weight, assisted, or null → Epley 1RM (weightM applies; repM does not affect 1RM)
+  if (weight != null && reps != null)
+    return weight * weightM * (1 + reps / 30.0);
   return null;
 }
 
@@ -49,6 +54,8 @@ function computeBestAchievement(
   allCompletedWorkouts: CompletedWorkout[],
   weightUnit: string,
   excludeWarmup: boolean = false,
+  countUnilateralDouble: boolean = false,
+  doubleWeightForPaired: boolean = false,
 ): BestAchievement | null {
   const today = new Date();
   const currentWeekStart = startOfWeek(today, { weekStartsOn: 1 });
@@ -64,6 +71,8 @@ function computeBestAchievement(
   const lastWeekBest = new Map<number, number>();
   for (const workout of lastWeekWorkouts) {
     for (const ex of workout.exercises) {
+      const weightM = doubleWeightForPaired && ex.double_weight ? 2 : 1;
+      const repM = countUnilateralDouble && ex.is_unilateral ? 2 : 1;
       for (const set of ex.sets) {
         if (excludeWarmup && set.is_warmup) continue;
         const metric = getProgressionMetric(
@@ -71,6 +80,8 @@ function computeBestAchievement(
           set.reps,
           set.time,
           ex.exercise_tracking_type,
+          weightM,
+          repM,
         );
         if (metric == null) continue;
         const prev = lastWeekBest.get(ex.exercise_id) ?? -Infinity;
@@ -86,6 +97,8 @@ function computeBestAchievement(
   >();
   for (const workout of workoutsThisWeek) {
     for (const ex of workout.exercises) {
+      const weightM = doubleWeightForPaired && ex.double_weight ? 2 : 1;
+      const repM = countUnilateralDouble && ex.is_unilateral ? 2 : 1;
       for (const set of ex.sets) {
         if (excludeWarmup && set.is_warmup) continue;
         const metric = getProgressionMetric(
@@ -93,6 +106,8 @@ function computeBestAchievement(
           set.reps,
           set.time,
           ex.exercise_tracking_type,
+          weightM,
+          repM,
         );
         if (metric == null) continue;
         const prev = thisWeekBest.get(ex.exercise_id);
@@ -163,6 +178,8 @@ export default function WeeklySummaryCard({
   weightUnit,
   streak,
   excludeWarmup = false,
+  countUnilateralDouble = false,
+  doubleWeightForPaired = false,
 }: Props) {
   const totalDuration = useMemo(
     () => workoutsThisWeek.reduce((sum, w) => sum + (w.duration ?? 0), 0),
@@ -173,15 +190,26 @@ export default function WeeklySummaryCard({
     let vol = 0;
     for (const workout of workoutsThisWeek) {
       for (const ex of workout.exercises) {
+        const weightM = doubleWeightForPaired && ex.double_weight ? 2 : 1;
+        const repM = countUnilateralDouble && ex.is_unilateral ? 2 : 1;
         for (const set of ex.sets) {
-          if ((!excludeWarmup || !set.is_warmup) && set.weight != null && set.reps != null) {
-            vol += set.weight * set.reps;
+          if (
+            (!excludeWarmup || !set.is_warmup) &&
+            set.weight != null &&
+            set.reps != null
+          ) {
+            vol += set.weight * weightM * set.reps * repM;
           }
         }
       }
     }
     return vol;
-  }, [workoutsThisWeek, excludeWarmup]);
+  }, [
+    workoutsThisWeek,
+    excludeWarmup,
+    countUnilateralDouble,
+    doubleWeightForPaired,
+  ]);
 
   const bestAchievement = useMemo(
     () =>
@@ -190,8 +218,17 @@ export default function WeeklySummaryCard({
         allCompletedWorkouts,
         weightUnit,
         excludeWarmup,
+        countUnilateralDouble,
+        doubleWeightForPaired,
       ),
-    [workoutsThisWeek, allCompletedWorkouts, weightUnit, excludeWarmup],
+    [
+      workoutsThisWeek,
+      allCompletedWorkouts,
+      weightUnit,
+      excludeWarmup,
+      countUnilateralDouble,
+      doubleWeightForPaired,
+    ],
   );
 
   const volumeLabel = `${Math.round(totalVolume).toLocaleString()} ${weightUnit}`;

--- a/components/charts/VolumeBarChart.tsx
+++ b/components/charts/VolumeBarChart.tsx
@@ -11,6 +11,8 @@ interface VolumeBarChartProps {
   timeRange: string;
   weightUnit: string;
   excludeWarmup?: boolean;
+  countUnilateralDouble?: boolean;
+  doubleWeightForPaired?: boolean;
 }
 
 interface Bucket {
@@ -26,6 +28,8 @@ const groupVolumeByTime = (
   timeRange: string,
   weightUnit: string,
   excludeWarmup: boolean = false,
+  countUnilateralDouble: boolean = false,
+  doubleWeightForPaired: boolean = false,
 ): Bucket[] => {
   type InternalBucket = Bucket & { internalKey: string };
   const buckets: InternalBucket[] = [];
@@ -155,9 +159,12 @@ const groupVolumeByTime = (
     if (idx === undefined) return;
 
     workout.exercises.forEach((exercise) => {
+      const weightM = doubleWeightForPaired && exercise.double_weight ? 2 : 1;
+      const repM = countUnilateralDouble && exercise.is_unilateral ? 2 : 1;
       exercise.sets.forEach((set) => {
         if ((!excludeWarmup || !set.is_warmup) && set.weight && set.reps) {
-          buckets[idx].value += (set.weight * set.reps) / tonDivisor;
+          buckets[idx].value +=
+            (set.weight * weightM * set.reps * repM) / tonDivisor;
         }
       });
     });
@@ -175,6 +182,8 @@ export const VolumeBarChart: React.FC<VolumeBarChartProps> = ({
   timeRange,
   weightUnit,
   excludeWarmup = false,
+  countUnilateralDouble = false,
+  doubleWeightForPaired = false,
 }) => {
   const { width: screenWidth } = useWindowDimensions();
 
@@ -185,8 +194,17 @@ export const VolumeBarChart: React.FC<VolumeBarChartProps> = ({
         timeRange,
         weightUnit,
         excludeWarmup,
+        countUnilateralDouble,
+        doubleWeightForPaired,
       ),
-    [completedWorkouts, timeRange, weightUnit, excludeWarmup],
+    [
+      completedWorkouts,
+      timeRange,
+      weightUnit,
+      excludeWarmup,
+      countUnilateralDouble,
+      doubleWeightForPaired,
+    ],
   );
 
   if (buckets.length === 0) return null;

--- a/constants/WhatsNew.ts
+++ b/constants/WhatsNew.ts
@@ -163,7 +163,7 @@ The exercise info screen now includes a full history of every time you've perfor
     message: `
 ⚙️ New: Three New Stats Settings!
 
-Customize how your volume and stats are calculated with three new options in Settings:
+Customise how your volume and stats are calculated with three new options in Settings:
 
 • Exclude warm-up sets from stats so they don't skew your numbers.
 • Double dumbbell weight automatically, so you can log the weight of one dumbbell and have the total counted for you.

--- a/constants/WhatsNew.ts
+++ b/constants/WhatsNew.ts
@@ -158,6 +158,18 @@ Never miss a session. Set reminder notifications for your workouts directly from
 The exercise info screen now includes a full history of every time you've performed that exercise, showing weights, reps, time, and distance for each set from past sessions. Access it during a workout, from your plan, or anywhere else exercise info is available.
 `,
   },
+  {
+    version: 2620,
+    message: `
+⚙️ New: Three New Stats Settings!
+
+Customize how your volume and stats are calculated with three new options in Settings:
+
+• Exclude warm-up sets from stats so they don't skew your numbers.
+• Double dumbbell weight automatically, so you can log the weight of one dumbbell and have the total counted for you.
+• Double reps for single arm/leg exercises, so unilateral movements are counted correctly in your volume totals.
+`,
+  },
 ];
 
 // Derived from WHATS_NEW_ENTRIES to avoid drift between the constant and entries

--- a/hooks/useCompletedWorkoutsQuery.ts
+++ b/hooks/useCompletedWorkoutsQuery.ts
@@ -14,6 +14,8 @@ interface WorkoutResult {
   exercise_name: string;
   exercise_image: Uint8Array | null;
   exercise_tracking_type: string;
+  is_unilateral: number | null;
+  double_weight: number | null;
   set_id: number;
   set_number: number;
   weight: number | null;
@@ -36,6 +38,8 @@ export interface CompletedWorkout {
     exercise_name: string;
     exercise_image?: number[];
     exercise_tracking_type: string;
+    is_unilateral?: number;
+    double_weight?: number;
     sets: {
       set_id: number;
       set_number: number;
@@ -70,6 +74,8 @@ const fetchCompletedWorkouts = async (
         exercises.name AS exercise_name,
         exercises.image AS exercise_image,
         exercises.tracking_type AS exercise_tracking_type,
+        exercises.is_unilateral,
+        exercises.double_weight,
         completed_sets.id AS set_id,
         completed_sets.set_number,
         completed_sets.weight,
@@ -136,6 +142,8 @@ const fetchAndOrganize = async (
         exercise_name,
         exercise_image,
         exercise_tracking_type,
+        is_unilateral,
+        double_weight,
         set_id,
         set_number,
         weight,
@@ -175,6 +183,8 @@ const fetchAndOrganize = async (
             ? Array.from(exercise_image)
             : undefined,
           exercise_tracking_type,
+          is_unilateral: is_unilateral ?? 0,
+          double_weight: double_weight ?? 0,
           sets: [],
         };
         workout.exercises.push(exercise);
@@ -219,7 +229,9 @@ export const useCompletedWorkoutsQuery = (
   });
 };
 
-const getPreviousPeriodDates = (days: number): { startDate: string; endDate: string } => {
+const getPreviousPeriodDates = (
+  days: number,
+): { startDate: string; endDate: string } => {
   const endDate = new Date();
   endDate.setDate(endDate.getDate() - days - 1);
   const startDate = new Date(endDate);
@@ -241,8 +253,15 @@ export const usePreviousPeriodWorkoutsQuery = (
     : { startDate: "", endDate: "" };
 
   return useQuery<CompletedWorkout[]>({
-    queryKey: ["completedWorkouts", weightUnit, distanceUnit, timeRange, "prev"],
-    queryFn: () => fetchAndOrganize(weightUnit, distanceUnit, timeRange, startDate, endDate),
+    queryKey: [
+      "completedWorkouts",
+      weightUnit,
+      distanceUnit,
+      timeRange,
+      "prev",
+    ],
+    queryFn: () =>
+      fetchAndOrganize(weightUnit, distanceUnit, timeRange, startDate, endDate),
     enabled,
     staleTime: 0,
     gcTime: 0,
@@ -271,6 +290,8 @@ const fetchWorkoutHistoryForSession = async (
         ce.exercise_id,
         e.name AS exercise_name,
         e.tracking_type AS exercise_tracking_type,
+        e.is_unilateral,
+        e.double_weight,
         cs.id AS set_id,
         cs.set_number,
         cs.weight,
@@ -343,6 +364,8 @@ const fetchWorkoutHistoryForSession = async (
           exercise_id,
           exercise_name,
           exercise_tracking_type,
+          is_unilateral: item.is_unilateral ?? 0,
+          double_weight: item.double_weight ?? 0,
           sets: [],
         };
         workout.exercises.push(exercise);
@@ -379,7 +402,8 @@ export const useWorkoutSessionHistoryQuery = (
 ) => {
   return useQuery<CompletedWorkout[]>({
     queryKey: ["workoutSessionHistory", workoutId, weightUnit, distanceUnit],
-    queryFn: () => fetchWorkoutHistoryForSession(workoutId, weightUnit, distanceUnit),
+    queryFn: () =>
+      fetchWorkoutHistoryForSession(workoutId, weightUnit, distanceUnit),
     enabled: workoutId > 0,
     staleTime: 5 * 60 * 1000,
   });

--- a/hooks/useExerciseDetailQuery.ts
+++ b/hooks/useExerciseDetailQuery.ts
@@ -1,7 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { openDatabase } from "@/utils/database";
 import Bugsnag from "@bugsnag/expo";
-import { TrackedExerciseWithSets, CompletedSet } from "./useTrackedExercisesQuery";
+import {
+  TrackedExerciseWithSets,
+  CompletedSet,
+} from "./useTrackedExercisesQuery";
 
 interface PRSet extends CompletedSet {
   date_completed: string;
@@ -22,19 +25,23 @@ export interface ExerciseDetail {
   preRangeBaseline: number | null;
 }
 
-const progressionMetricCase = `
+const buildProgressionMetricCase = (weightM: number, repM: number) => `
   CASE e.tracking_type
-    WHEN 'weight' THEN cs.weight * (1 + cs.reps / 30.0)
+    WHEN 'weight' THEN (cs.weight * ${weightM}) * (1 + cs.reps / 30.0)
     WHEN 'assisted' THEN (CAST((SELECT value FROM settings WHERE key = 'bodyWeight') AS REAL) - cs.weight) * (1 + cs.reps / 30.0)
-    WHEN 'reps' THEN cs.reps
+    WHEN 'reps' THEN cs.reps * ${repM}
     WHEN 'time' THEN cs.time
     WHEN 'distance' THEN cs.distance
-    ELSE cs.weight * (1 + cs.reps / 30.0)
+    ELSE (cs.weight * ${weightM}) * (1 + cs.reps / 30.0)
   END
 `;
 
-const mapRowToCompletedSet = (row: any, trackingType: string | null): CompletedSet => {
-  const isWeight = !trackingType || trackingType === "weight" || trackingType === "assisted";
+const mapRowToCompletedSet = (
+  row: any,
+  trackingType: string | null,
+): CompletedSet => {
+  const isWeight =
+    !trackingType || trackingType === "weight" || trackingType === "assisted";
   return {
     set_number: row.set_number,
     weight: isWeight ? row.weight : undefined,
@@ -42,7 +49,9 @@ const mapRowToCompletedSet = (row: any, trackingType: string | null): CompletedS
     time: trackingType === "time" ? row.time : undefined,
     distance: trackingType === "distance" ? row.distance : undefined,
     date_completed: row.date_completed,
-    oneRepMax: isWeight ? Math.round(row.progression_metric * 10) / 10 : undefined,
+    oneRepMax: isWeight
+      ? Math.round(row.progression_metric * 10) / 10
+      : undefined,
     progressionMetric: row.progression_metric,
   };
 };
@@ -50,13 +59,27 @@ const mapRowToCompletedSet = (row: any, trackingType: string | null): CompletedS
 const fetchExerciseDetail = async (
   exerciseId: number,
   timeRange: string,
-  weightUnit: string,
   excludeWarmup = false,
+  countUnilateralDouble = false,
+  doubleWeightForPaired = false,
 ): Promise<ExerciseDetail | null> => {
   try {
     const db = await openDatabase("userData.db");
-    const convFactor = weightUnit === "lbs" ? 2.2046226 : 1;
-    const warmupFilter = excludeWarmup ? " AND (cs.is_warmup = FALSE OR cs.is_warmup IS NULL)" : "";
+    const warmupFilter = excludeWarmup
+      ? " AND (cs.is_warmup = FALSE OR cs.is_warmup IS NULL)"
+      : "";
+
+    const exerciseFlags = await db.getFirstAsync<{
+      is_unilateral: number;
+      double_weight: number;
+    }>(
+      "SELECT is_unilateral, double_weight FROM exercises WHERE exercise_id = ?",
+      [exerciseId],
+    );
+    const repM = countUnilateralDouble && exerciseFlags?.is_unilateral ? 2 : 1;
+    const weightM =
+      doubleWeightForPaired && exerciseFlags?.double_weight ? 2 : 1;
+    const progressionMetricCase = buildProgressionMetricCase(weightM, repM);
 
     // Fetch the best set per day for this exercise (time-range filtered).
     // ROW_NUMBER() deterministically picks the highest-metric set per date,
@@ -170,7 +193,9 @@ const fetchExerciseDetail = async (
       ORDER BY cw.date_completed DESC
       LIMIT 5
     `;
-    const recentRows = (await db.getAllAsync(recentQuery, [exerciseId])) as any[];
+    const recentRows = (await db.getAllAsync(recentQuery, [
+      exerciseId,
+    ])) as any[];
     const recentSessions: RecentSession[] = recentRows.map((r) => ({
       date_completed: r.date_completed,
       bestSet: mapRowToCompletedSet(r, trackingType),
@@ -195,7 +220,9 @@ const fetchExerciseDetail = async (
         ORDER BY DATE(cw.date_completed) DESC
         LIMIT 1
       `;
-      const baselineRow = (await db.getFirstAsync(baselineQuery, [exerciseId])) as {
+      const baselineRow = (await db.getFirstAsync(baselineQuery, [
+        exerciseId,
+      ])) as {
         baseline_metric: number | null;
       } | null;
       preRangeBaseline = baselineRow?.baseline_metric ?? null;
@@ -222,10 +249,27 @@ export const useExerciseDetailQuery = (
   timeRange: string,
   weightUnit: string,
   excludeWarmup = false,
+  countUnilateralDouble = false,
+  doubleWeightForPaired = false,
 ) => {
   return useQuery<ExerciseDetail | null>({
-    queryKey: ["exerciseDetail", exerciseId, timeRange, weightUnit, excludeWarmup],
-    queryFn: () => fetchExerciseDetail(exerciseId, timeRange, weightUnit, excludeWarmup),
+    queryKey: [
+      "exerciseDetail",
+      exerciseId,
+      timeRange,
+      weightUnit,
+      excludeWarmup,
+      countUnilateralDouble,
+      doubleWeightForPaired,
+    ],
+    queryFn: () =>
+      fetchExerciseDetail(
+        exerciseId,
+        timeRange,
+        excludeWarmup,
+        countUnilateralDouble,
+        doubleWeightForPaired,
+      ),
     enabled: exerciseId > 0,
     staleTime: 0,
     gcTime: 0,

--- a/hooks/useTrackedExercisesQuery.ts
+++ b/hooks/useTrackedExercisesQuery.ts
@@ -26,34 +26,49 @@ export interface TrackedExerciseWithSets extends TrackedExercise {
   allTimePR: number;
 }
 
+const buildTrackedProgressionCase = (
+  countUnilateralDouble: boolean,
+  doubleWeightForPaired: boolean,
+) => {
+  const wM = doubleWeightForPaired ? 2 : 1;
+  const rM = countUnilateralDouble ? 2 : 1;
+  return `
+    CASE e.tracking_type
+      WHEN 'weight' THEN (cs.weight * CASE WHEN e.double_weight = 1 THEN ${wM} ELSE 1 END) * (1 + cs.reps / 30.0)
+      WHEN 'assisted' THEN (CAST((SELECT value FROM settings WHERE key = 'bodyWeight') AS REAL) - cs.weight) * (1 + cs.reps / 30.0)
+      WHEN 'reps' THEN cs.reps * CASE WHEN e.is_unilateral = 1 THEN ${rM} ELSE 1 END
+      WHEN 'time' THEN cs.time
+      WHEN 'distance' THEN cs.distance
+      ELSE (cs.weight * CASE WHEN e.double_weight = 1 THEN ${wM} ELSE 1 END) * (1 + cs.reps / 30.0)
+    END
+  `;
+};
+
 const fetchTrackedExercises = async (
   timeRange: string,
   excludeWarmup: boolean = false,
+  countUnilateralDouble: boolean = false,
+  doubleWeightForPaired: boolean = false,
 ): Promise<TrackedExerciseWithSets[]> => {
   try {
     const db = await openDatabase("userData.db");
+    const progressionCase = buildTrackedProgressionCase(
+      countUnilateralDouble,
+      doubleWeightForPaired,
+    );
 
     let query = `
-      SELECT 
+      SELECT
         te.*,
         e.name,
-        e.tracking_type, -- Include tracking type
+        e.tracking_type,
         cs.weight,
         cs.reps,
         cs.time,
         cs.distance,
         cs.set_number,
         DATE(cw.date_completed) AS date_completed,
-        MAX(
-        CASE e.tracking_type
-          WHEN 'weight' THEN cs.weight * (1 + cs.reps / 30.0)
-          WHEN 'assisted' THEN (CAST((SELECT value FROM settings WHERE key = 'bodyWeight') AS REAL) - cs.weight) * (1 + cs.reps / 30.0)
-          WHEN 'reps' THEN cs.reps
-          WHEN 'time' THEN cs.time
-          WHEN 'distance' THEN cs.distance
-          ELSE cs.weight * (1 + cs.reps / 30.0)
-        END
-      ) AS progression_metric
+        MAX(${progressionCase}) AS progression_metric
       FROM tracked_exercises te
       LEFT JOIN exercises e ON te.exercise_id = e.exercise_id
       LEFT JOIN completed_exercises ce ON te.exercise_id = ce.exercise_id
@@ -79,16 +94,7 @@ const fetchTrackedExercises = async (
     const allTimePRQuery = `
       SELECT
         te.exercise_id,
-        MAX(
-          CASE e.tracking_type
-            WHEN 'weight' THEN cs.weight * (1 + cs.reps / 30.0)
-            WHEN 'assisted' THEN (CAST((SELECT value FROM settings WHERE key = 'bodyWeight') AS REAL) - cs.weight) * (1 + cs.reps / 30.0)
-            WHEN 'reps' THEN cs.reps
-            WHEN 'time' THEN cs.time
-            WHEN 'distance' THEN cs.distance
-            ELSE cs.weight * (1 + cs.reps / 30.0)
-          END
-        ) AS all_time_pr
+        MAX(${progressionCase}) AS all_time_pr
       FROM tracked_exercises te
       LEFT JOIN exercises e ON te.exercise_id = e.exercise_id
       LEFT JOIN completed_exercises ce ON te.exercise_id = ce.exercise_id
@@ -162,10 +168,15 @@ const fetchTrackedExercises = async (
   }
 };
 
-export const useTrackedExercisesQuery = (timeRange: string, excludeWarmup: boolean = false) => {
+export const useTrackedExercisesQuery = (
+  timeRange: string,
+  excludeWarmup: boolean = false,
+  countUnilateralDouble: boolean = false,
+  doubleWeightForPaired: boolean = false,
+) => {
   return useQuery<TrackedExerciseWithSets[], Error>({
-    queryKey: ["trackedExercises", timeRange, excludeWarmup],
-    queryFn: () => fetchTrackedExercises(timeRange, excludeWarmup),
+    queryKey: ["trackedExercises", timeRange, excludeWarmup, countUnilateralDouble, doubleWeightForPaired],
+    queryFn: () => fetchTrackedExercises(timeRange, excludeWarmup, countUnilateralDouble, doubleWeightForPaired),
     staleTime: 0,
     gcTime: 0,
   });

--- a/utils/database.ts
+++ b/utils/database.ts
@@ -17,6 +17,8 @@ export interface Exercise {
   description: string;
   tracking_type?: string;
   favorite?: number;
+  is_unilateral?: number;
+  double_weight?: number;
 }
 
 export interface SavedWorkout {
@@ -221,6 +223,10 @@ export const copyDataFromAppDataToUserData = async (): Promise<void> => {
                     return row[col] !== existingEntry.tracking_type;
                   case "equipment":
                     return row[col] !== existingEntry.equipment;
+                  case "is_unilateral":
+                    return row[col] !== (existingEntry as any).is_unilateral;
+                  case "double_weight":
+                    return row[col] !== (existingEntry as any).double_weight;
                   default:
                     return false;
                 }
@@ -276,6 +282,8 @@ export const copyDataFromAppDataToUserData = async (): Promise<void> => {
       "description",
       "is_deleted",
       "tracking_type",
+      "is_unilateral",
+      "double_weight",
     ],
     true, // Exclude the auto-incremented exercise_id for userData
   );
@@ -288,6 +296,39 @@ export const copyDataFromAppDataToUserData = async (): Promise<void> => {
     );
 
     console.log("Data copy completed and version updated.");
+  }
+};
+
+export const syncExerciseFlagsFromAppData = async (): Promise<void> => {
+  const userDataDB = await openDatabase("userData.db");
+  const versionResult = await userDataDB.getFirstAsync<SettingsEntry>(
+    "SELECT value FROM settings WHERE key = 'dataVersion'",
+  );
+  if (Number(versionResult?.value) >= 1.9) return;
+
+  const appDataDB = await openDatabase("appData2.db");
+  const appExercises = await appDataDB.getAllAsync<{
+    exercise_id: number;
+    is_unilateral: number;
+    double_weight: number;
+  }>("SELECT exercise_id, is_unilateral, double_weight FROM exercises");
+
+  await userDataDB.execAsync("BEGIN TRANSACTION");
+  try {
+    for (const ex of appExercises) {
+      await userDataDB.runAsync(
+        "UPDATE exercises SET is_unilateral = ?, double_weight = ? WHERE app_exercise_id = ?",
+        [ex.is_unilateral ?? 0, ex.double_weight ?? 0, ex.exercise_id],
+      );
+    }
+    await userDataDB.runAsync(
+      "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+      ["dataVersion", "1.9"],
+    );
+    await userDataDB.execAsync("COMMIT");
+  } catch (err) {
+    await userDataDB.execAsync("ROLLBACK");
+    Bugsnag.notify(err as Error);
   }
 };
 
@@ -1064,6 +1105,8 @@ export const insertDefaultSettings = async () => {
     { key: "workoutReminderDays", value: "[]" },
     { key: "workoutReminderTime", value: "08:00" },
     { key: "excludeWarmupSets", value: "false" },
+    { key: "countUnilateralDouble", value: "false" },
+    { key: "doubleWeightForPaired", value: "false" },
   ];
 
   // Loop through each default setting
@@ -1114,6 +1157,8 @@ export interface Settings {
   workoutReminderDays: string;
   workoutReminderTime: string;
   excludeWarmupSets: string;
+  countUnilateralDouble: string;
+  doubleWeightForPaired: string;
 }
 
 export const fetchSettings = async (): Promise<Settings> => {

--- a/utils/database.ts
+++ b/utils/database.ts
@@ -904,6 +904,8 @@ interface CompletedWorkoutRow {
   exercise_image: Uint8Array | null;
   exercise_order: number;
   exercise_tracking_type: string | null;
+  is_unilateral: number | null;
+  double_weight: number | null;
   set_id: number;
   set_number: number | null;
   weight: number | null;
@@ -935,6 +937,8 @@ export const fetchCompletedWorkoutById = async (
         e.name as exercise_name, 
         e.image as exercise_image, 
         e.tracking_type as exercise_tracking_type,
+        e.is_unilateral,
+        e.double_weight,
         cs.id as set_id,
         cs.set_number,
         cs.weight,
@@ -991,6 +995,8 @@ export const fetchCompletedWorkoutById = async (
               ? Array.from(row.exercise_image)
               : undefined,
             exercise_tracking_type: row.exercise_tracking_type || "weight",
+            is_unilateral: row.is_unilateral ?? 0,
+            double_weight: row.double_weight ?? 0,
             sets: [],
             exercise_order: row.exercise_order, // Track exercise order
           };

--- a/utils/database.ts
+++ b/utils/database.ts
@@ -126,6 +126,8 @@ export const copyDataFromAppDataToUserData = async (): Promise<void> => {
     equipment: string | null;
     tracking_type: string | null;
     is_deleted: number;
+    is_unilateral?: boolean;
+    double_weight?: boolean;
   }
 
   const dataVersionEntry: SettingsEntry | null =
@@ -224,9 +226,9 @@ export const copyDataFromAppDataToUserData = async (): Promise<void> => {
                   case "equipment":
                     return row[col] !== existingEntry.equipment;
                   case "is_unilateral":
-                    return row[col] !== (existingEntry as any).is_unilateral;
+                    return row[col] !== existingEntry.is_unilateral;
                   case "double_weight":
-                    return row[col] !== (existingEntry as any).double_weight;
+                    return row[col] !== existingEntry.double_weight;
                   default:
                     return false;
                 }

--- a/utils/initAppDataDB.ts
+++ b/utils/initAppDataDB.ts
@@ -27,7 +27,7 @@ const copyDatabase = async (): Promise<void> => {
     );
   }
 
-  if (!dbFile.exists || dataVersion === null || dataVersion < 1.7) {
+  if (!dbFile.exists || dataVersion === null || dataVersion < 1.9) {
     console.log("Copying appData2.db ...");
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const asset = Asset.fromModule(require(`../assets/db/${DATABASE_NAME}`));

--- a/utils/initUserDataDB.ts
+++ b/utils/initUserDataDB.ts
@@ -207,6 +207,12 @@ export async function initUserDataDB() {
   const workout_imageUrlExists = user_workoutsResult.some(
     (column: any) => column.name === "image_url",
   );
+  const isUnilateralExists = exercisesResult.some(
+    (column: any) => column.name === "is_unilateral",
+  );
+  const doubleWeightExists = exercisesResult.some(
+    (column: any) => column.name === "double_weight",
+  );
 
   // If the column does not exist, add it
   if (!app_exercise_idExists) {
@@ -303,6 +309,16 @@ export async function initUserDataDB() {
   if (!workout_imageUrlExists) {
     await db.execAsync(`
       ALTER TABLE user_workouts ADD COLUMN image_url TEXT;
+    `);
+  }
+  if (!isUnilateralExists) {
+    await db.execAsync(`
+      ALTER TABLE exercises ADD COLUMN is_unilateral BOOLEAN DEFAULT FALSE;
+    `);
+  }
+  if (!doubleWeightExists) {
+    await db.execAsync(`
+      ALTER TABLE exercises ADD COLUMN double_weight BOOLEAN DEFAULT FALSE;
     `);
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Three new stats settings now customise volume calculations: exclude warm-up sets, automatically double dumbbell weights for paired exercises, and double repetitions for single-arm/leg exercises.
  * Custom exercises can now be marked as unilateral or paired/double-weight to accurately reflect in stats.
  * Stats, progress metrics, and volume displays across the app now reflect these personalised calculation settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/isotronic/MuscleQuest/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->