### PR TITLE
fix: workout timer, history data fetching, set deletion, time input handling

### DIFF
--- a/app/(app)/(tabs)/(stats)/edit-history.tsx
+++ b/app/(app)/(tabs)/(stats)/edit-history.tsx
@@ -72,7 +72,9 @@ export default function EditCompletedWorkoutScreen() {
       sets: exercise.sets.map((set, setIndex) => {
         const key = `${exerciseIndex}-${setIndex}`;
         if (weightInputs[key] === undefined) return set;
-        const parsedWeight = parseFloat(weightInputs[key] || "0");
+        const raw = weightInputs[key];
+        if (raw == null || raw.trim() === "") return { ...set, weight: null };
+        const parsedWeight = parseFloat(raw);
         return { ...set, weight: isNaN(parsedWeight) ? null : parsedWeight };
       }),
     }));

--- a/app/(app)/(tabs)/(stats)/edit-history.tsx
+++ b/app/(app)/(tabs)/(stats)/edit-history.tsx
@@ -43,7 +43,6 @@ export default function EditCompletedWorkoutScreen() {
     weightUnit,
     distanceUnit,
   );
-
   // Update exercises when workout data is available
   useEffect(() => {
     if (workoutData) {
@@ -64,10 +63,21 @@ export default function EditCompletedWorkoutScreen() {
   }, [exercises]);
 
   const handleSave = () => {
-    // Blur each input to ensure all onBlur events are fired
     Object.values(weightInputRefs.current).forEach((input) => input?.blur());
 
-    editWorkout.mutate(exercises, {
+    // Merge weightInputs into exercises synchronously — onBlur state updates
+    // are batched by React and won't be applied before mutate runs.
+    const finalExercises = exercises.map((exercise, exerciseIndex) => ({
+      ...exercise,
+      sets: exercise.sets.map((set, setIndex) => {
+        const key = `${exerciseIndex}-${setIndex}`;
+        if (weightInputs[key] === undefined) return set;
+        const parsedWeight = parseFloat(weightInputs[key] || "0");
+        return { ...set, weight: isNaN(parsedWeight) ? null : parsedWeight };
+      }),
+    }));
+
+    editWorkout.mutate(finalExercises, {
       onSuccess: () => {
         router.back();
       },
@@ -96,13 +106,21 @@ export default function EditCompletedWorkoutScreen() {
         options={{
           headerRight: () => (
             <View style={styles.headerRight}>
-              <IconButton
-                icon="content-save-outline"
-                size={35}
-                style={{ marginRight: 0 }}
-                iconColor={Colors.dark.tint}
-                onPressIn={handleSave}
-              />
+              {editWorkout.isPending ? (
+                <ActivityIndicator
+                  size={24}
+                  color={Colors.dark.tint}
+                  style={{ marginRight: 12 }}
+                />
+              ) : (
+                <IconButton
+                  icon="content-save-outline"
+                  size={35}
+                  style={{ marginRight: 0 }}
+                  iconColor={Colors.dark.tint}
+                  onPressIn={handleSave}
+                />
+              )}
             </View>
           ),
         }}

--- a/app/(app)/(tabs)/(stats)/edit-history.tsx
+++ b/app/(app)/(tabs)/(stats)/edit-history.tsx
@@ -10,6 +10,8 @@ import { CompletedWorkout } from "@/hooks/useCompletedWorkoutsQuery";
 import { useEditCompletedWorkoutMutation } from "@/hooks/useEditCompletedWorkoutMutation";
 import { ActivityIndicator } from "react-native-paper";
 import { useCompletedWorkoutByIdQuery } from "@/hooks/useCompletedWorkoutByIdQuery";
+import { formatFromTotalSeconds, convertToTotalSeconds } from "@/utils/utility";
+import { TimeInput } from "@/components/TimeInput";
 import Bugsnag from "@bugsnag/expo";
 
 export default function EditCompletedWorkoutScreen() {
@@ -36,7 +38,11 @@ export default function EditCompletedWorkoutScreen() {
     error: workoutError,
   } = useCompletedWorkoutByIdQuery(Number(id), weightUnit, distanceUnit);
 
-  const editWorkout = useEditCompletedWorkoutMutation(Number(id), weightUnit, distanceUnit);
+  const editWorkout = useEditCompletedWorkoutMutation(
+    Number(id),
+    weightUnit,
+    distanceUnit,
+  );
 
   // Update exercises when workout data is available
   useEffect(() => {
@@ -185,22 +191,18 @@ export default function EditCompletedWorkoutScreen() {
                   </View>
                 ) : exercise.exercise_tracking_type === "time" ? (
                   <View style={styles.inputContainer}>
-                    <ThemedText style={styles.label}>Time (Seconds)</ThemedText>
-                    <TextInput
-                      style={styles.input}
-                      placeholder="Time"
-                      value={String(set.time || "")}
-                      placeholderTextColor={Colors.dark.subText}
-                      selectTextOnFocus={true}
-                      keyboardType="numeric"
-                      onChangeText={(value: string) => {
+                    <ThemedText style={styles.label}>Time (Min:Sec)</ThemedText>
+                    <TimeInput
+                      value={formatFromTotalSeconds(set.time || 0)}
+                      onChange={(value: string) => {
                         setExercises((prev) => {
                           const updated = [...prev];
                           updated[exerciseIndex].sets[setIndex].time =
-                            Number(value);
+                            convertToTotalSeconds(value);
                           return updated;
                         });
                       }}
+                      style={styles.timeInput}
                     />
                   </View>
                 ) : exercise.exercise_tracking_type === "reps" ? (
@@ -281,5 +283,15 @@ const styles = StyleSheet.create({
     color: Colors.dark.text,
     fontSize: 18,
     textAlign: "right",
+  },
+  timeInput: {
+    width: 96,
+    padding: 10,
+    borderColor: Colors.dark.subText,
+    borderWidth: 1,
+    borderRadius: 8,
+    color: Colors.dark.text,
+    fontSize: 18,
+    textAlign: "center",
   },
 });

--- a/app/(app)/(tabs)/(stats)/history-details.tsx
+++ b/app/(app)/(tabs)/(stats)/history-details.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { View, StyleSheet, ScrollView, Alert } from "react-native";
 import { Image } from "expo-image";
 import { ThemedView } from "@/components/ThemedView";
@@ -27,6 +27,7 @@ export default function HistoryDetailsScreen() {
   const { id } = useLocalSearchParams();
   const [workout, setWorkout] = useState<CompletedWorkout | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
 
   const {
     data: settings,
@@ -41,26 +42,42 @@ export default function HistoryDetailsScreen() {
   const countUnilateralDouble = settings?.countUnilateralDouble === "true";
   const doubleWeightForPaired = settings?.doubleWeightForPaired === "true";
 
+  useEffect(() => {
+    if (settingsError instanceof Error) {
+      Bugsnag.notify(settingsError);
+    }
+  }, [settingsError]);
+
   const deleteMutation = useDeleteCompletedWorkoutMutation();
 
   useFocusEffect(
     useCallback(() => {
       const numId = Number(Array.isArray(id) ? id[0] : id);
-      if (!numId) return;
+      if (!numId) {
+        setIsLoading(false);
+        setWorkout(null);
+        return;
+      }
 
       let cancelled = false;
       setIsLoading(true);
+      setError(null);
 
       fetchCompletedWorkoutById(numId, weightUnit, distanceUnit)
         .then((data) => {
           if (!cancelled) {
             setWorkout(data);
+            setError(null);
             setIsLoading(false);
           }
         })
-        .catch((error) => {
-          if (!cancelled) setIsLoading(false);
-          Bugsnag.notify(error);
+        .catch((err) => {
+          if (!cancelled) {
+            setError(err instanceof Error ? err : new Error(String(err)));
+            setWorkout(null);
+            setIsLoading(false);
+            Bugsnag.notify(err);
+          }
         });
 
       return () => {
@@ -94,7 +111,7 @@ export default function HistoryDetailsScreen() {
     doubleWeightForPaired,
   ]);
 
-  if (isLoading || !workout || settingsLoading) {
+  if (isLoading || settingsLoading) {
     return (
       <ThemedView style={styles.container}>
         <ActivityIndicator size="large" color={Colors.dark.text} />
@@ -102,11 +119,16 @@ export default function HistoryDetailsScreen() {
     );
   }
 
-  if (settingsError) {
-    if (settingsError instanceof Error) {
-      Bugsnag.notify(settingsError);
-      return <ThemedText>Error: {settingsError.message}</ThemedText>;
-    }
+  if (settingsError instanceof Error) {
+    return <ThemedText>Error: {settingsError.message}</ThemedText>;
+  }
+
+  if (error) {
+    return <ThemedText>Error: {error.message}</ThemedText>;
+  }
+
+  if (!workout) {
+    return null;
   }
 
   const isoDateString = workout.date_completed.replace(" ", "T");

--- a/app/(app)/(tabs)/(stats)/history-details.tsx
+++ b/app/(app)/(tabs)/(stats)/history-details.tsx
@@ -19,6 +19,7 @@ import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { useSettingsQuery } from "@/hooks/useSettingsQuery";
 import { useCompletedWorkoutByIdQuery } from "@/hooks/useCompletedWorkoutByIdQuery";
 import { useDeleteCompletedWorkoutMutation } from "@/hooks/useDeleteCompletedWorkoutMutation";
+import { formatFromTotalSeconds } from "@/utils/utility";
 import Bugsnag from "@bugsnag/expo";
 
 const fallbackImage = require("@/assets/images/placeholder.webp");
@@ -106,7 +107,13 @@ export default function HistoryDetailsScreen() {
 
       return parseFloat((exerciseAcc + exerciseVolume).toFixed(1));
     }, 0);
-  }, [workout, bodyWeight, excludeWarmup, countUnilateralDouble, doubleWeightForPaired]);
+  }, [
+    workout,
+    bodyWeight,
+    excludeWarmup,
+    countUnilateralDouble,
+    doubleWeightForPaired,
+  ]);
 
   if (isWorkoutLoading || !workout || settingsLoading) {
     return (
@@ -253,7 +260,9 @@ export default function HistoryDetailsScreen() {
                     </ThemedText>
                     {exercise.exercise_tracking_type === "time" ? (
                       <ThemedText style={styles.setText}>
-                        {set.time} Seconds
+                        {set.time != null
+                          ? formatFromTotalSeconds(set.time)
+                          : "—"}
                       </ThemedText>
                     ) : exercise.exercise_tracking_type === "reps" ? (
                       <ThemedText style={styles.setText}>

--- a/app/(app)/(tabs)/(stats)/history-details.tsx
+++ b/app/(app)/(tabs)/(stats)/history-details.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { View, StyleSheet, ScrollView, Alert } from "react-native";
 import { Image } from "expo-image";
 import { ThemedView } from "@/components/ThemedView";
@@ -11,13 +11,12 @@ import {
   useLocalSearchParams,
   useFocusEffect,
 } from "expo-router";
-import { CompletedWorkout } from "@/hooks/useCompletedWorkoutsQuery";
-import { fetchExerciseImagesByIds } from "@/utils/database";
 import { byteArrayToBase64 } from "@/utils/utility";
 import { parseISO, format } from "date-fns";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { useSettingsQuery } from "@/hooks/useSettingsQuery";
-import { useCompletedWorkoutByIdQuery } from "@/hooks/useCompletedWorkoutByIdQuery";
+import { fetchCompletedWorkoutById } from "@/utils/database";
+import { CompletedWorkout } from "@/hooks/useCompletedWorkoutsQuery";
 import { useDeleteCompletedWorkoutMutation } from "@/hooks/useDeleteCompletedWorkoutMutation";
 import { formatFromTotalSeconds } from "@/utils/utility";
 import Bugsnag from "@bugsnag/expo";
@@ -27,6 +26,7 @@ const fallbackImage = require("@/assets/images/placeholder.webp");
 export default function HistoryDetailsScreen() {
   const { id } = useLocalSearchParams();
   const [workout, setWorkout] = useState<CompletedWorkout | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   const {
     data: settings,
@@ -43,53 +43,32 @@ export default function HistoryDetailsScreen() {
 
   const deleteMutation = useDeleteCompletedWorkoutMutation();
 
-  const {
-    data: workoutData,
-    isLoading: isWorkoutLoading,
-    error: workoutError,
-    refetch,
-  } = useCompletedWorkoutByIdQuery(Number(id), weightUnit, distanceUnit);
-
-  useEffect(() => {
-    if (workoutData) {
-      // Collect unique exercise IDs
-      const exerciseIds = workoutData.exercises.map(
-        (exercise) => exercise.exercise_id,
-      );
-
-      // Fetch images for these exercise IDs and attach them to the exercises
-      const fetchImages = async () => {
-        try {
-          const imagesMap = await fetchExerciseImagesByIds(exerciseIds);
-
-          // Attach images to exercises
-          const exercisesWithImages = workoutData.exercises.map((exercise) => ({
-            ...exercise,
-            exercise_image: imagesMap[exercise.exercise_id],
-          }));
-
-          // Update workout data with exercises including images
-          setWorkout({
-            ...workoutData,
-            exercises: exercisesWithImages,
-          });
-        } catch (error: any) {
-          console.error("Error fetching exercise images:", error);
-          Bugsnag.notify(error);
-        }
-      };
-
-      fetchImages();
-    }
-  }, [workoutData]);
-
   useFocusEffect(
     useCallback(() => {
-      refetch();
-    }, [refetch]),
+      const numId = Number(Array.isArray(id) ? id[0] : id);
+      if (!numId) return;
+
+      let cancelled = false;
+      setIsLoading(true);
+
+      fetchCompletedWorkoutById(numId, weightUnit, distanceUnit)
+        .then((data) => {
+          if (!cancelled) {
+            setWorkout(data);
+            setIsLoading(false);
+          }
+        })
+        .catch((error) => {
+          if (!cancelled) setIsLoading(false);
+          Bugsnag.notify(error);
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    }, [id, weightUnit, distanceUnit]),
   );
 
-  // Calculate total volume
   const totalVolume = useMemo(() => {
     if (!workout) return 0;
 
@@ -115,7 +94,7 @@ export default function HistoryDetailsScreen() {
     doubleWeightForPaired,
   ]);
 
-  if (isWorkoutLoading || !workout || settingsLoading) {
+  if (isLoading || !workout || settingsLoading) {
     return (
       <ThemedView style={styles.container}>
         <ActivityIndicator size="large" color={Colors.dark.text} />
@@ -123,11 +102,10 @@ export default function HistoryDetailsScreen() {
     );
   }
 
-  if (settingsError || workoutError) {
-    const error = settingsError || workoutError;
-    if (error instanceof Error) {
-      Bugsnag.notify(error);
-      return <ThemedText>Error: {error.message}</ThemedText>;
+  if (settingsError) {
+    if (settingsError instanceof Error) {
+      Bugsnag.notify(settingsError);
+      return <ThemedText>Error: {settingsError.message}</ThemedText>;
     }
   }
 
@@ -226,10 +204,8 @@ export default function HistoryDetailsScreen() {
         {/* Exercise List */}
         <View style={styles.exerciseList}>
           {workout.exercises.map((exercise) => {
-            // Check if the image exists
             let imageUri = "";
             if (exercise.exercise_image) {
-              // Convert the image blob to Base64
               const base64Image = byteArrayToBase64(exercise.exercise_image);
               imageUri = `data:image/webp;base64,${base64Image}`;
             }

--- a/app/(app)/(workout)/index.tsx
+++ b/app/(app)/(workout)/index.tsx
@@ -33,6 +33,7 @@ import {
   linkCompletedWorkoutToWorkout,
 } from "@/utils/database";
 import { cancelRestNotifications } from "@/utils/restNotification";
+import { convertTimeStrToSeconds } from "@/utils/utility";
 import { useQueryClient } from "@tanstack/react-query";
 import { UserExercise, Workout } from "@/store/workoutStore";
 
@@ -518,7 +519,7 @@ export default function WorkoutOverviewScreen() {
                 set_number: parseInt(setIndex) + 1,
                 weight: set.weight ? parseFloat(set.weight) : null,
                 reps: set.reps ? parseInt(set.reps) : null,
-                time: set.time ? parseInt(set.time) : null,
+                time: set.time ? convertTimeStrToSeconds(set.time) : null,
                 distance:
                   set.distance !== "" && set.distance != null
                     ? parseFloat(set.distance)

--- a/app/(app)/(workout)/workout-session.tsx
+++ b/app/(app)/(workout)/workout-session.tsx
@@ -632,6 +632,18 @@ export default function WorkoutSessionScreen() {
         style: "destructive",
         onPress: () => {
           removeSet(index);
+          const newSetIndex =
+            useActiveWorkoutStore.getState().currentSetIndices[
+              currentExerciseIndex
+            ] ?? 0;
+          setSlots((prev) => {
+            const u = [...prev] as [SlotData, SlotData, SlotData];
+            u[currentSlotIndex] = {
+              exerciseIndex: currentExerciseIndex,
+              setIndex: newSetIndex,
+            };
+            return u;
+          });
         },
       },
     ]);

--- a/app/(app)/(workout)/workout-session.tsx
+++ b/app/(app)/(workout)/workout-session.tsx
@@ -632,14 +632,13 @@ export default function WorkoutSessionScreen() {
         style: "destructive",
         onPress: () => {
           removeSet(index);
-          const newSetIndex =
-            useActiveWorkoutStore.getState().currentSetIndices[
-              currentExerciseIndex
-            ] ?? 0;
+          const st = useActiveWorkoutStore.getState();
+          const newExerciseIndex = st.currentExerciseIndex;
+          const newSetIndex = st.currentSetIndices[newExerciseIndex] ?? 0;
           setSlots((prev) => {
             const u = [...prev] as [SlotData, SlotData, SlotData];
             u[currentSlotIndex] = {
-              exerciseIndex: currentExerciseIndex,
+              exerciseIndex: newExerciseIndex,
               setIndex: newSetIndex,
             };
             return u;

--- a/components/SessionSetInfo.tsx
+++ b/components/SessionSetInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useCallback } from "react";
 import { View, TextInput, StyleSheet } from "react-native";
 import {
   IconButton,
@@ -107,7 +107,6 @@ export default function SessionSetInfo({
   onToggleSetType,
 }: SessionSetInfoProps) {
   const [menuVisible, setMenuVisible] = useState(false);
-  const [timeInput, setTimeInput] = useState(time);
   const [timerModalVisible, setTimerModalVisible] = useState(false);
 
   const weightMinusPress = useContinuousPress(
@@ -135,13 +134,7 @@ export default function SessionSetInfo({
     useCallback(() => handleDistanceChange(1), [handleDistanceChange]),
   );
 
-  // Update timeInput when time prop changes
-  useEffect(() => {
-    setTimeInput(time);
-  }, [time]);
-
-  // Format display value - now always formatted
-  const displayValue = formatTimeInput(timeInput);
+  const displayValue = formatTimeInput(time);
 
   const openMenu = () => setMenuVisible(true);
   const closeMenu = () => setMenuVisible(false);
@@ -403,6 +396,7 @@ export default function SessionSetInfo({
           </View>
           <View style={styles.inputContainer}>
             <TimeInput
+              key={`${exercise_id}-${currentSetIndex}`}
               value={displayValue}
               onChange={handleTimeInputChange}
               style={styles.input}


### PR DESCRIPTION
## Summary by Sourcery

Improve time-based workout handling and history loading for completed workouts.

New Features:
- Allow editing time-based sets using a dedicated time input with minutes/seconds formatting in the completed workout editor.

Bug Fixes:
- Fix completed workout history details loading by fetching workouts directly and handling loading and error states correctly.
- Ensure deletion of a set in an active workout updates the current set selection so navigation and timers point at the correct set.
- Prevent stale or out-of-sync time values in workout session set inputs by deriving display values from the source time state and resetting inputs on set changes.
- Correct conversion of string time inputs to total seconds when saving workouts and editing completed workouts to the database.
- Ensure pending weight input changes are applied before saving edited completed workouts to avoid losing updates.

Enhancements:
- Show a saving indicator in the edit completed workout screen header while a save mutation is in progress.
- Format displayed and historical time-based set durations using a human-friendly time format instead of raw seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Time tracking now displays in Min:Sec format for improved readability.
  * Added loading indicator during workout save operations.

* **Bug Fixes**
  * Fixed data synchronisation when deleting workout sets.
  * Improved time display consistency across history screens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/isotronic/MuscleQuest/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->