### PR TITLE
feat: workout insights, draft persistence, and plan editing improvements

### DIFF
--- a/app/(app)/(create-plan)/create-workout.tsx
+++ b/app/(app)/(create-plan)/create-workout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   StyleSheet,
   View,
@@ -45,10 +45,15 @@ export default function CreateWorkoutScreen() {
     addWorkout,
     changeWorkoutName,
     setWorkouts,
-    setDraftContext,
-    setDraftId,
+    saveDraftEntry,
+    clearDraftEntry,
     clearDraft,
   } = useWorkoutStore();
+
+  const draftKey =
+    existingWorkoutId !== null
+      ? `standalone:${existingWorkoutId}`
+      : "standalone:null";
 
   const { data: standaloneWorkouts } = useStandaloneWorkoutsQuery();
   const createMutation = useCreateStandaloneWorkout();
@@ -59,25 +64,16 @@ export default function CreateWorkoutScreen() {
     "pending" | "continue" | "fresh"
   >("pending");
 
-  const startFreshSession = useCallback(() => {
-    setDraftContext("standalone");
-    setDraftId(existingWorkoutId);
-  }, [existingWorkoutId, setDraftContext, setDraftId]);
-
   // Check for a persisted draft once on mount, after store hydrates
   useEffect(() => {
     const checkDraft = () => {
-      const {
-        workouts: storedWorkouts,
-        draftContext,
-        draftId,
-      } = useWorkoutStore.getState();
+      const { drafts } = useWorkoutStore.getState();
+      const draft = drafts[draftKey];
       const hasDraft =
-        draftContext === "standalone" &&
-        draftId === existingWorkoutId &&
-        storedWorkouts.length > 0 &&
-        (storedWorkouts[0].exercises.length > 0 ||
-          storedWorkouts[0].name.trim() !== "");
+        !!draft &&
+        draft.workouts.length > 0 &&
+        (draft.workouts[0].exercises.length > 0 ||
+          draft.workouts[0].name.trim() !== "");
 
       if (hasDraft) {
         Alert.alert(
@@ -88,14 +84,15 @@ export default function CreateWorkoutScreen() {
               text: "Discard Changes",
               style: "destructive",
               onPress: () => {
+                clearDraftEntry(draftKey);
                 clearDraft();
-                startFreshSession();
                 setDraftDecision("fresh");
               },
             },
             {
               text: "Continue",
               onPress: () => {
+                setWorkouts(draft.workouts);
                 initializedWorkoutId.current = existingWorkoutId ?? null;
                 setDraftDecision("continue");
               },
@@ -103,8 +100,6 @@ export default function CreateWorkoutScreen() {
           ],
         );
       } else {
-        if (draftContext !== null) clearDraft();
-        startFreshSession();
         setDraftDecision("fresh");
       }
     };
@@ -116,6 +111,14 @@ export default function CreateWorkoutScreen() {
       return unsub;
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-save draft on every change so it survives app close
+  useEffect(() => {
+    if (draftDecision === "pending") return;
+    const workout = workouts[0];
+    if (!workout || (!workout.exercises.length && !workout.name.trim())) return;
+    saveDraftEntry(draftKey, { workouts });
+  }, [workouts, draftDecision]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Initialise workoutStore for this screen — runs once per workout id
   useEffect(() => {
@@ -149,12 +152,14 @@ export default function CreateWorkoutScreen() {
 
       if (savedRef.current) {
         savedRef.current = false;
+        clearDraftEntry(draftKey);
         clearDraft();
         return navigation.dispatch(e.data.action);
       }
 
       const workout = workouts[0];
       if (!workout || (!workout.exercises.length && !workout.name.trim())) {
+        clearDraftEntry(draftKey);
         clearDraft();
         return navigation.dispatch(e.data.action);
       }
@@ -168,6 +173,7 @@ export default function CreateWorkoutScreen() {
             text: "Discard",
             style: "destructive",
             onPress: () => {
+              clearDraftEntry(draftKey);
               clearDraft();
               navigation.dispatch(e.data.action);
             },
@@ -176,7 +182,7 @@ export default function CreateWorkoutScreen() {
       );
     });
     return unsubscribe;
-  }, [navigation, workouts, clearDraft]);
+  }, [navigation, workouts, clearDraft, clearDraftEntry, draftKey]);
 
   const handleAddExercise = () => {
     router.push("/(app)/(create-plan)/exercises?index=0");
@@ -204,6 +210,7 @@ export default function CreateWorkoutScreen() {
       }
 
       await queryClient.invalidateQueries({ queryKey: ["standaloneWorkouts"] });
+      clearDraftEntry(draftKey);
       savedRef.current = true;
       router.back();
     } catch (error: any) {

--- a/app/(app)/(create-plan)/create-workout.tsx
+++ b/app/(app)/(create-plan)/create-workout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   StyleSheet,
   View,
@@ -45,14 +45,82 @@ export default function CreateWorkoutScreen() {
     addWorkout,
     changeWorkoutName,
     setWorkouts,
+    setDraftContext,
+    setDraftId,
+    clearDraft,
   } = useWorkoutStore();
 
   const { data: standaloneWorkouts } = useStandaloneWorkoutsQuery();
   const createMutation = useCreateStandaloneWorkout();
   const updateMutation = useUpdateStandaloneWorkout();
 
+  // 'pending' until draft check resolves; then 'continue' or 'fresh'
+  const [draftDecision, setDraftDecision] = useState<
+    "pending" | "continue" | "fresh"
+  >("pending");
+
+  const startFreshSession = useCallback(() => {
+    setDraftContext("standalone");
+    setDraftId(existingWorkoutId);
+  }, [existingWorkoutId, setDraftContext, setDraftId]);
+
+  // Check for a persisted draft once on mount, after store hydrates
+  useEffect(() => {
+    const checkDraft = () => {
+      const {
+        workouts: storedWorkouts,
+        draftContext,
+        draftId,
+      } = useWorkoutStore.getState();
+      const hasDraft =
+        draftContext === "standalone" &&
+        draftId === existingWorkoutId &&
+        storedWorkouts.length > 0 &&
+        (storedWorkouts[0].exercises.length > 0 ||
+          storedWorkouts[0].name.trim() !== "");
+
+      if (hasDraft) {
+        Alert.alert(
+          "Continue Editing?",
+          "You have unsaved changes from your last session. Would you like to continue?",
+          [
+            {
+              text: "Discard Changes",
+              style: "destructive",
+              onPress: () => {
+                clearDraft();
+                startFreshSession();
+                setDraftDecision("fresh");
+              },
+            },
+            {
+              text: "Continue",
+              onPress: () => {
+                initializedWorkoutId.current = existingWorkoutId ?? null;
+                setDraftDecision("continue");
+              },
+            },
+          ],
+        );
+      } else {
+        if (draftContext !== null) clearDraft();
+        startFreshSession();
+        setDraftDecision("fresh");
+      }
+    };
+
+    if (useWorkoutStore.persist.hasHydrated()) {
+      checkDraft();
+    } else {
+      const unsub = useWorkoutStore.persist.onFinishHydration(checkDraft);
+      return unsub;
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Initialise workoutStore for this screen — runs once per workout id
   useEffect(() => {
+    if (draftDecision === "pending" || draftDecision === "continue") return;
+
     const sentinel = existingWorkoutId ?? null;
     if (initializedWorkoutId.current === sentinel) return;
     if (existingWorkoutId && standaloneWorkouts) {
@@ -72,7 +140,7 @@ export default function CreateWorkoutScreen() {
     clearWorkouts();
     addWorkout({ name: "", exercises: [], id: -Date.now() });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [existingWorkoutId, standaloneWorkouts]);
+  }, [draftDecision, existingWorkoutId, standaloneWorkouts]);
 
   // Guard back-navigation when there are unsaved changes
   useEffect(() => {
@@ -81,13 +149,13 @@ export default function CreateWorkoutScreen() {
 
       if (savedRef.current) {
         savedRef.current = false;
-        clearWorkouts();
+        clearDraft();
         return navigation.dispatch(e.data.action);
       }
 
       const workout = workouts[0];
       if (!workout || (!workout.exercises.length && !workout.name.trim())) {
-        clearWorkouts();
+        clearDraft();
         return navigation.dispatch(e.data.action);
       }
 
@@ -100,7 +168,7 @@ export default function CreateWorkoutScreen() {
             text: "Discard",
             style: "destructive",
             onPress: () => {
-              clearWorkouts();
+              clearDraft();
               navigation.dispatch(e.data.action);
             },
           },
@@ -108,7 +176,7 @@ export default function CreateWorkoutScreen() {
       );
     });
     return unsubscribe;
-  }, [navigation, workouts, clearWorkouts]);
+  }, [navigation, workouts, clearDraft]);
 
   const handleAddExercise = () => {
     router.push("/(app)/(create-plan)/exercises?index=0");

--- a/app/(app)/(create-plan)/create.tsx
+++ b/app/(app)/(create-plan)/create.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from "react";
+import { useEffect, useState, useRef } from "react";
 import {
   StyleSheet,
   View,
@@ -57,11 +57,14 @@ export default function CreatePlanScreen() {
     changeWorkoutName,
     planSchedule,
     setPlanSchedule,
-    setDraftContext,
-    setDraftId,
-    setDraftName,
+    saveDraftEntry,
+    clearDraftEntry,
     clearDraft,
   } = useWorkoutStore();
+
+  const currentPlanId = planId ? Number(planId) : null;
+  const draftKey =
+    currentPlanId !== null ? `plan:${currentPlanId}` : "plan:null";
   const { data: settings } = useSettingsQuery();
   const weeklyGoal = Number(settings?.weeklyGoal ?? 3);
   const { planName, setPlanName, planSaved, setPlanSaved, handleSavePlan } =
@@ -73,26 +76,14 @@ export default function CreatePlanScreen() {
     "pending" | "continue" | "fresh"
   >("pending");
 
-  const startFreshSession = useCallback(() => {
-    const currentPlanId = planId ? Number(planId) : null;
-    setDraftContext("plan");
-    setDraftId(currentPlanId);
-  }, [planId, setDraftContext, setDraftId]);
-
   // Check for a persisted draft once on mount, after store hydrates
   useEffect(() => {
     const checkDraft = () => {
-      const {
-        workouts: storedWorkouts,
-        draftContext,
-        draftId,
-        draftName,
-      } = useWorkoutStore.getState();
-      const currentPlanId = planId ? Number(planId) : null;
+      const { drafts } = useWorkoutStore.getState();
+      const draft = drafts[draftKey];
       const hasDraft =
-        draftContext === "plan" &&
-        draftId === currentPlanId &&
-        (storedWorkouts.length > 0 || draftName.trim() !== "");
+        !!draft &&
+        (draft.workouts.length > 0 || (draft.draftName ?? "").trim() !== "");
 
       if (hasDraft) {
         Alert.alert(
@@ -103,8 +94,8 @@ export default function CreatePlanScreen() {
               text: "Discard Changes",
               style: "destructive",
               onPress: () => {
+                clearDraftEntry(draftKey);
                 clearDraft();
-                startFreshSession();
                 setDraftDecision("fresh");
                 if (!planId) setDataLoaded(true);
               },
@@ -112,7 +103,10 @@ export default function CreatePlanScreen() {
             {
               text: "Continue",
               onPress: () => {
-                setPlanName(draftName);
+                setWorkouts(draft.workouts);
+                if (draft.planImageUrl) setPlanImageUrl(draft.planImageUrl);
+                if (draft.planSchedule) setPlanSchedule(draft.planSchedule);
+                setPlanName(draft.draftName ?? "");
                 setDraftDecision("continue");
                 if (!planId) setDataLoaded(true);
               },
@@ -120,9 +114,6 @@ export default function CreatePlanScreen() {
           ],
         );
       } else {
-        // Clear stale draft from a different context
-        if (draftContext !== null) clearDraft();
-        startFreshSession();
         setDraftDecision("fresh");
         if (!planId) setDataLoaded(true);
       }
@@ -136,15 +127,25 @@ export default function CreatePlanScreen() {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Sync plan name into persisted draft so it survives app close
+  // Auto-save draft on every change so it survives app close
   useEffect(() => {
-    if (draftDecision !== "pending") {
-      setDraftName(planName);
-    }
-  }, [planName, draftDecision, setDraftName]);
+    if (draftDecision === "pending") return;
+    if (workouts.length === 0 && !planName.trim()) return;
+    saveDraftEntry(draftKey, {
+      workouts,
+      planImageUrl,
+      planSchedule,
+      draftName: planName,
+    });
+  }, [workouts, planImageUrl, planSchedule, planName, draftDecision]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (!existingPlan || draftDecision === "pending") return;
+    if (draftDecision === "pending") return;
+    if (draftDecision === "continue") {
+      setDataLoaded(true);
+      return;
+    }
+    if (!existingPlan) return;
 
     if (draftDecision === "fresh") {
       setPlanName(existingPlan.name);
@@ -209,12 +210,14 @@ export default function CreatePlanScreen() {
       if (planSaved) {
         queryClient.invalidateQueries({ queryKey: ["plans"] });
         queryClient.invalidateQueries({ queryKey: ["activePlan"] });
+        clearDraftEntry(draftKey);
         clearDraft();
         setPlanSaved(false);
         return navigation.dispatch(e.data.action);
       }
 
       if (!workouts.length && !planName.trim()) {
+        clearDraftEntry(draftKey);
         clearDraft();
         return navigation.dispatch(e.data.action);
       }
@@ -228,6 +231,7 @@ export default function CreatePlanScreen() {
             text: "Discard",
             style: "destructive",
             onPress: () => {
+              clearDraftEntry(draftKey);
               clearDraft();
               setPlanSaved(false);
               navigation.dispatch(e.data.action);
@@ -243,6 +247,8 @@ export default function CreatePlanScreen() {
     workouts,
     planName,
     clearDraft,
+    clearDraftEntry,
+    draftKey,
     planSaved,
     setPlanSaved,
     queryClient,
@@ -296,6 +302,8 @@ export default function CreatePlanScreen() {
         Number(planId),
         existingPlan?.app_plan_id,
       );
+
+      clearDraftEntry(draftKey);
 
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["plans"] }),

--- a/app/(app)/(create-plan)/create.tsx
+++ b/app/(app)/(create-plan)/create.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import {
   StyleSheet,
   View,
@@ -43,7 +43,7 @@ export default function CreatePlanScreen() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { planId } = useLocalSearchParams();
-  const [dataLoaded, setDataLoaded] = useState(!planId);
+  const [dataLoaded, setDataLoaded] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const scrollRef = useRef<ScrollViewType>(null);
   const {
@@ -51,14 +51,16 @@ export default function CreatePlanScreen() {
     planImageUrl,
     setPlanImageUrl,
     setWorkouts,
-    clearWorkouts,
     addWorkout,
     removeWorkout,
     reorderWorkouts,
     changeWorkoutName,
     planSchedule,
     setPlanSchedule,
-    clearPlanSchedule,
+    setDraftContext,
+    setDraftId,
+    setDraftName,
+    clearDraft,
   } = useWorkoutStore();
   const { data: settings } = useSettingsQuery();
   const weeklyGoal = Number(settings?.weeklyGoal ?? 3);
@@ -66,8 +68,85 @@ export default function CreatePlanScreen() {
     useCreatePlan();
   const { data: existingPlan } = usePlanQuery(planId ? Number(planId) : null);
 
+  // 'pending' until draft check resolves; then 'continue' or 'fresh'
+  const [draftDecision, setDraftDecision] = useState<
+    "pending" | "continue" | "fresh"
+  >("pending");
+
+  const startFreshSession = useCallback(() => {
+    const currentPlanId = planId ? Number(planId) : null;
+    setDraftContext("plan");
+    setDraftId(currentPlanId);
+  }, [planId, setDraftContext, setDraftId]);
+
+  // Check for a persisted draft once on mount, after store hydrates
   useEffect(() => {
-    if (existingPlan) {
+    const checkDraft = () => {
+      const {
+        workouts: storedWorkouts,
+        draftContext,
+        draftId,
+        draftName,
+      } = useWorkoutStore.getState();
+      const currentPlanId = planId ? Number(planId) : null;
+      const hasDraft =
+        draftContext === "plan" &&
+        draftId === currentPlanId &&
+        (storedWorkouts.length > 0 || draftName.trim() !== "");
+
+      if (hasDraft) {
+        Alert.alert(
+          "Continue Editing?",
+          "You have unsaved changes from your last session. Would you like to continue?",
+          [
+            {
+              text: "Discard Changes",
+              style: "destructive",
+              onPress: () => {
+                clearDraft();
+                startFreshSession();
+                setDraftDecision("fresh");
+                if (!planId) setDataLoaded(true);
+              },
+            },
+            {
+              text: "Continue",
+              onPress: () => {
+                setPlanName(draftName);
+                setDraftDecision("continue");
+                if (!planId) setDataLoaded(true);
+              },
+            },
+          ],
+        );
+      } else {
+        // Clear stale draft from a different context
+        if (draftContext !== null) clearDraft();
+        startFreshSession();
+        setDraftDecision("fresh");
+        if (!planId) setDataLoaded(true);
+      }
+    };
+
+    if (useWorkoutStore.persist.hasHydrated()) {
+      checkDraft();
+    } else {
+      const unsub = useWorkoutStore.persist.onFinishHydration(checkDraft);
+      return unsub;
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Sync plan name into persisted draft so it survives app close
+  useEffect(() => {
+    if (draftDecision !== "pending") {
+      setDraftName(planName);
+    }
+  }, [planName, draftDecision, setDraftName]);
+
+  useEffect(() => {
+    if (!existingPlan || draftDecision === "pending") return;
+
+    if (draftDecision === "fresh") {
       setPlanName(existingPlan.name);
       setPlanImageUrl(existingPlan.image_url);
 
@@ -85,7 +164,7 @@ export default function CreatePlanScreen() {
             if (entries.length > 0 && existingPlan.workouts) {
               const schedule: Record<number, number> = {};
               for (const entry of entries) {
-                const idx = existingPlan.workouts.findIndex(
+                const idx = existingPlan.workouts!.findIndex(
                   (w) => w.id === entry.workout_id,
                 );
                 if (idx !== -1) {
@@ -102,18 +181,20 @@ export default function CreatePlanScreen() {
                 planId: existingPlan.id,
               });
             });
-            // Non-critical: schedule defaults to empty
           });
+
+        setDataLoaded(true);
+
+        return () => {
+          cancelled = true;
+        };
       }
-
-      setDataLoaded(true);
-
-      return () => {
-        cancelled = true;
-      };
     }
+
+    setDataLoaded(true);
   }, [
     existingPlan,
+    draftDecision,
     setPlanName,
     setWorkouts,
     setPlanImageUrl,
@@ -128,13 +209,13 @@ export default function CreatePlanScreen() {
       if (planSaved) {
         queryClient.invalidateQueries({ queryKey: ["plans"] });
         queryClient.invalidateQueries({ queryKey: ["activePlan"] });
-        clearWorkouts();
-        clearPlanSchedule();
+        clearDraft();
         setPlanSaved(false);
         return navigation.dispatch(e.data.action);
       }
 
       if (!workouts.length && !planName.trim()) {
+        clearDraft();
         return navigation.dispatch(e.data.action);
       }
 
@@ -147,8 +228,7 @@ export default function CreatePlanScreen() {
             text: "Discard",
             style: "destructive",
             onPress: () => {
-              clearWorkouts();
-              clearPlanSchedule();
+              clearDraft();
               setPlanSaved(false);
               navigation.dispatch(e.data.action);
             },
@@ -162,8 +242,7 @@ export default function CreatePlanScreen() {
     navigation,
     workouts,
     planName,
-    clearWorkouts,
-    clearPlanSchedule,
+    clearDraft,
     planSaved,
     setPlanSaved,
     queryClient,

--- a/app/(app)/(create-plan)/sets-overview.tsx
+++ b/app/(app)/(create-plan)/sets-overview.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { StyleSheet, FlatList, TouchableOpacity, View } from "react-native";
-import { Button } from "react-native-paper";
+import { Button, Divider } from "react-native-paper";
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
 import { router, Stack, useLocalSearchParams } from "expo-router";
@@ -18,7 +18,6 @@ export default function SetsOverviewScreen() {
   const { data: settings } = useSettingsQuery();
 
   const totalSeconds = settings ? parseInt(settings?.defaultRestTime) : 0;
-  const weightUnit = settings?.weightUnit || "kg";
   const distanceUnit = settings?.distanceUnit || "m";
   const defaultRepsMin = 8;
   const defaultRepsMax = 12;
@@ -60,6 +59,43 @@ export default function SetsOverviewScreen() {
       .removeSetFromExercise(Number(workoutIndex), Number(exerciseId), index);
   };
 
+  const handleAddWarmupSet = () => {
+    let insertIndex = 0;
+    for (let i = sets.length - 1; i >= 0; i--) {
+      if (sets[i].isWarmup) {
+        insertIndex = i + 1;
+        break;
+      }
+    }
+    const lastWarmupSet = sets.filter((s) => s.isWarmup).at(-1);
+    const newSet: Set = lastWarmupSet
+      ? {
+          ...lastWarmupSet,
+          isWarmup: true,
+          isDropSet: false,
+          isToFailure: false,
+        }
+      : {
+          repsMin: defaultRepsMin,
+          repsMax: defaultRepsMax,
+          restMinutes: Math.floor(defaultTotalSeconds / 60),
+          restSeconds: defaultTotalSeconds % 60,
+          time: defaultTime,
+          distance: undefined,
+          isWarmup: true,
+          isDropSet: false,
+          isToFailure: false,
+        };
+    useWorkoutStore
+      .getState()
+      .insertSetAtExercise(
+        Number(workoutIndex),
+        Number(exerciseId),
+        insertIndex,
+        newSet,
+      );
+  };
+
   const renderSetItem = ({ item, index }: { item: Set; index: number }) => {
     const repRange =
       item.repsMin === item.repsMax
@@ -74,40 +110,50 @@ export default function SetsOverviewScreen() {
       ? formatFromTotalSeconds(item.time)
       : formatFromTotalSeconds(defaultTime);
 
+    const previousSet = index > 0 ? sets[index - 1] : null;
+    const showGroupDivider =
+      previousSet !== null &&
+      (previousSet.isWarmup ?? false) !== (item.isWarmup ?? false);
+
     return (
-      <ThemedView style={styles.setItem}>
-        <TouchableOpacity
-          onPress={() => handleEditSet(index)}
-          style={styles.setContent}
+      <>
+        {showGroupDivider && <Divider style={styles.groupDivider} />}
+        <ThemedView
+          style={[styles.setItem, item.isWarmup && styles.warmupSetItem]}
         >
-          <ThemedView style={styles.setTextContainer}>
-            <ThemedText style={styles.setTitle}>Set {index + 1}</ThemedText>
-            <ThemedText style={styles.setInfo}>
-              {item.isWarmup ? "Warm-up, " : ""}
-              {item.isDropSet ? "Drop set, " : ""}
-              {item.isToFailure ? "To failure, " : ""}
-              {trackingType === "time"
-                ? `${formattedTime}, `
-                : trackingType === "distance"
-                  ? item.distance !== undefined
-                    ? `${item.distance} ${distanceUnit}, `
-                    : ""
-                  : repRange !== undefined
-                    ? `${repRange} Reps, `
-                    : ""}
-              {item.restMinutes}:{String(item.restSeconds).padStart(2, "0")}{" "}
-              Rest
-            </ThemedText>
-          </ThemedView>
-        </TouchableOpacity>
-        <MaterialCommunityIcons
-          name="close"
-          size={24}
-          color={Colors.dark.text}
-          onPress={() => handleDeleteSet(index)}
-          style={styles.deleteIcon}
-        />
-      </ThemedView>
+          <TouchableOpacity
+            onPress={() => handleEditSet(index)}
+            style={styles.setContent}
+          >
+            <ThemedView style={styles.setTextContainer}>
+              <ThemedText style={styles.setTitle}>Set {index + 1}</ThemedText>
+              <ThemedText style={styles.setInfo}>
+                {item.isWarmup ? "Warm-up, " : ""}
+                {item.isDropSet ? "Drop set, " : ""}
+                {item.isToFailure ? "To failure, " : ""}
+                {trackingType === "time"
+                  ? `${formattedTime}, `
+                  : trackingType === "distance"
+                    ? item.distance !== undefined
+                      ? `${item.distance} ${distanceUnit}, `
+                      : ""
+                    : repRange !== undefined
+                      ? `${repRange} Reps, `
+                      : ""}
+                {item.restMinutes}:{String(item.restSeconds).padStart(2, "0")}{" "}
+                Rest
+              </ThemedText>
+            </ThemedView>
+          </TouchableOpacity>
+          <MaterialCommunityIcons
+            name="close"
+            size={24}
+            color={Colors.dark.text}
+            onPress={() => handleDeleteSet(index)}
+            style={styles.deleteIcon}
+          />
+        </ThemedView>
+      </>
     );
   };
 
@@ -116,6 +162,16 @@ export default function SetsOverviewScreen() {
       <Stack.Screen
         options={{
           title: exercise?.name,
+          headerRight: () => (
+            <Button
+              labelStyle={styles.buttonLabel}
+              onPress={() =>
+                router.push(`/(app)/exercise-info?exercise_id=${exerciseId}`)
+              }
+            >
+              Details
+            </Button>
+          ),
         }}
       />
       {supersetPartner && (
@@ -136,12 +192,10 @@ export default function SetsOverviewScreen() {
         <Button
           mode="outlined"
           labelStyle={styles.buttonLabel}
-          style={styles.detailsButton}
-          onPress={() =>
-            router.push(`/(app)/exercise-info?exercise_id=${exerciseId}`)
-          }
+          style={styles.addSetButton}
+          onPress={handleAddWarmupSet}
         >
-          Details
+          Add Warm-up
         </Button>
         <Button
           mode="contained"
@@ -207,6 +261,14 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
   },
+  warmupSetItem: {
+    borderLeftWidth: 3,
+    borderLeftColor: Colors.dark.badgeWarmup,
+  },
+  groupDivider: {
+    marginBottom: 8,
+    backgroundColor: Colors.dark.subText,
+  },
   setContent: {
     flex: 1,
   },
@@ -235,11 +297,8 @@ const styles = StyleSheet.create({
     gap: 8,
     paddingBottom: 16,
   },
-  detailsButton: {
-    flex: 1,
-  },
   addSetButton: {
-    flex: 5,
+    flex: 1,
   },
   buttonLabel: {
     fontSize: 16,

--- a/app/(app)/(tabs)/(plans)/index.tsx
+++ b/app/(app)/(tabs)/(plans)/index.tsx
@@ -11,9 +11,12 @@ import { useStandaloneWorkoutsQuery } from "@/hooks/useStandaloneWorkoutsQuery";
 import StandaloneWorkoutListItem from "@/components/StandaloneWorkoutListItem";
 import { Workout } from "@/store/workoutStore";
 import Bugsnag from "@bugsnag/expo";
+import { useSettingsQuery } from "@/hooks/useSettingsQuery";
 
 export default function PlansScreen() {
   const { data: plans, isLoading, isError, error } = useAllPlansQuery();
+  const { data: settings } = useSettingsQuery();
+  const countUnilateralDouble = settings?.countUnilateralDouble === "true";
   const {
     data: standaloneWorkouts,
     isLoading: standaloneIsLoading,
@@ -110,6 +113,7 @@ export default function PlansScreen() {
                 key={item.id!.toString()}
                 workout={item}
                 onPress={() => handleViewWorkout(item)}
+                countUnilateralDouble={countUnilateralDouble}
               />
             ))
           ) : (

--- a/app/(app)/(tabs)/(plans)/overview.tsx
+++ b/app/(app)/(tabs)/(plans)/overview.tsx
@@ -26,13 +26,58 @@ import {
 import { useState } from "react";
 import Bugsnag from "@bugsnag/expo";
 import { Notes } from "@/components/Notes";
+import { useSettingsQuery } from "@/hooks/useSettingsQuery";
+import { useWorkoutDurationEstimate } from "@/hooks/useWorkoutDurationEstimate";
+import { formatDurationEstimate } from "@/utils/estimateWorkoutDuration";
+import type { Workout } from "@/store/workoutStore";
 
 const fallbackImage = require("@/assets/images/placeholder.webp");
+
+function PlanWorkoutCard({
+  workout,
+  index,
+  planId,
+  countUnilateralDouble,
+}: {
+  workout: Workout;
+  index: number;
+  planId: string | string[];
+  countUnilateralDouble: boolean;
+}) {
+  const { estimate } = useWorkoutDurationEstimate(
+    workout.exercises,
+    countUnilateralDouble,
+  );
+  return (
+    <TouchableOpacity
+      onPress={() =>
+        router.push({
+          pathname: "/workout-details",
+          params: {
+            planId: String(planId),
+            workoutIndex: String(index),
+          },
+        })
+      }
+      style={styles.workoutCard}
+    >
+      <ThemedText style={styles.workoutTitle}>
+        {workout.name || `Day ${index + 1}`}
+      </ThemedText>
+      <ThemedText style={styles.workoutInfo}>
+        {workout.exercises.length} Exercises
+        {estimate ? `  ·  ~${formatDurationEstimate(estimate)}` : ""}
+      </ThemedText>
+    </TouchableOpacity>
+  );
+}
 
 export default function PlanOverviewScreen() {
   const { planId } = useLocalSearchParams();
   const { data: plan, isLoading, error } = usePlanQuery(Number(planId));
   const { data: scheduleEntries = [] } = usePlanScheduleQuery(Number(planId));
+  const { data: settings } = useSettingsQuery();
+  const countUnilateralDouble = settings?.countUnilateralDouble === "true";
   const deletePlanMutation = useDeletePlanMutation();
   const setActivePlanMutation = useSetActivePlanMutation();
 
@@ -145,26 +190,13 @@ export default function PlanOverviewScreen() {
         </View>
 
         {plan?.workouts.map((workout, index) => (
-          <TouchableOpacity
+          <PlanWorkoutCard
             key={index.toString()}
-            onPress={() =>
-              router.push({
-                pathname: "/workout-details",
-                params: {
-                  planId: String(planId),
-                  workoutIndex: String(index),
-                },
-              })
-            }
-            style={styles.workoutCard}
-          >
-            <ThemedText style={styles.workoutTitle}>
-              {workout.name || `Day ${index + 1}`}
-            </ThemedText>
-            <ThemedText style={styles.workoutInfo}>
-              {workout.exercises.length} Exercises
-            </ThemedText>
-          </TouchableOpacity>
+            workout={workout}
+            index={index}
+            planId={planId}
+            countUnilateralDouble={countUnilateralDouble}
+          />
         ))}
 
         <WeeklyScheduleDisplay

--- a/app/(app)/(tabs)/(stats)/index.tsx
+++ b/app/(app)/(tabs)/(stats)/index.tsx
@@ -120,24 +120,26 @@ export default function StatsScreen() {
     parseInt(selectedTimeRange),
   );
 
-  useEffect(() => {
-    const anyError = error || exercisesError || trackedError;
-    if (anyError) {
-      Bugsnag.notify(
-        anyError instanceof Error ? anyError : new Error(String(anyError)),
-      );
-    }
-  }, [error, exercisesError, trackedError]);
   const { data: prevWorkouts } = usePreviousPeriodWorkoutsQuery(
     weightUnit,
     distanceUnit,
     parseInt(selectedTimeRange),
   );
 
-  const { data: allWorkouts } = useCompletedWorkoutsQuery(
-    weightUnit,
-    distanceUnit,
-  );
+  const {
+    data: allWorkouts,
+    isLoading: isLoadingAllWorkouts,
+    error: allWorkoutsError,
+  } = useCompletedWorkoutsQuery(weightUnit, distanceUnit);
+
+  useEffect(() => {
+    const anyError = error || exercisesError || trackedError || allWorkoutsError;
+    if (anyError) {
+      Bugsnag.notify(
+        anyError instanceof Error ? anyError : new Error(String(anyError)),
+      );
+    }
+  }, [error, exercisesError, trackedError, allWorkoutsError]);
 
   const thisWeekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
   const thisWeekEnd = endOfWeek(new Date(), { weekStartsOn: 1 });
@@ -208,7 +210,11 @@ export default function StatsScreen() {
     });
   }, [router, trackedExercises]);
 
-  const isLoading = isLoadingWorkouts || isLoadingExercises || isLoadingTracked;
+  const isLoading =
+    isLoadingWorkouts ||
+    isLoadingExercises ||
+    isLoadingTracked ||
+    isLoadingAllWorkouts;
 
   if (isLoading) {
     return (
@@ -218,7 +224,7 @@ export default function StatsScreen() {
     );
   }
 
-  const anyError = error || exercisesError || trackedError;
+  const anyError = error || exercisesError || trackedError || allWorkoutsError;
   if (anyError) {
     return (
       <ThemedView style={styles.centered}>

--- a/app/(app)/(tabs)/(stats)/index.tsx
+++ b/app/(app)/(tabs)/(stats)/index.tsx
@@ -9,6 +9,8 @@ import {
   useCompletedWorkoutsQuery,
   usePreviousPeriodWorkoutsQuery,
 } from "@/hooks/useCompletedWorkoutsQuery";
+import { startOfWeek, endOfWeek } from "date-fns";
+import { useWeeklyStreak } from "@/hooks/useWeeklyStreak";
 import { useExercisesQuery } from "@/hooks/useExercisesQuery";
 import { Colors } from "@/constants/Colors";
 import { WorkoutHistorySection } from "@/components/stats/WorkoutHistorySection";
@@ -130,6 +132,30 @@ export default function StatsScreen() {
     weightUnit,
     distanceUnit,
     parseInt(selectedTimeRange),
+  );
+
+  const { data: allWorkouts } = useCompletedWorkoutsQuery(
+    weightUnit,
+    distanceUnit,
+  );
+
+  const thisWeekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
+  const thisWeekEnd = endOfWeek(new Date(), { weekStartsOn: 1 });
+  const thisWeekWorkouts = allWorkouts?.filter((w) => {
+    const d = new Date(w.date_completed);
+    return d >= thisWeekStart && d <= thisWeekEnd;
+  });
+  const uniqueWorkoutDaysCount = new Set(
+    thisWeekWorkouts?.map((w) => new Date(w.date_completed).toDateString()),
+  ).size;
+  const weeklyGoal = Number(settings?.weeklyGoal ?? 0);
+  const weeklyGoalReached =
+    uniqueWorkoutDaysCount >= weeklyGoal && weeklyGoal > 0;
+  const { streak } = useWeeklyStreak(
+    allWorkouts,
+    weeklyGoal,
+    uniqueWorkoutDaysCount,
+    weeklyGoalReached,
   );
 
   const insights = useStatsInsights(
@@ -254,7 +280,7 @@ export default function StatsScreen() {
               biggestGainLabel={insights.biggestGainLabel}
               biggestGainValue={insights.biggestGainValue}
               topBodyPart={insights.topBodyPart}
-              streak={null}
+              streak={streak}
               weightUnit={weightUnit}
             />
           </View>

--- a/app/(app)/(tabs)/(stats)/index.tsx
+++ b/app/(app)/(tabs)/(stats)/index.tsx
@@ -133,7 +133,8 @@ export default function StatsScreen() {
   } = useCompletedWorkoutsQuery(weightUnit, distanceUnit);
 
   useEffect(() => {
-    const anyError = error || exercisesError || trackedError || allWorkoutsError;
+    const anyError =
+      error || exercisesError || trackedError || allWorkoutsError;
     if (anyError) {
       Bugsnag.notify(
         anyError instanceof Error ? anyError : new Error(String(anyError)),
@@ -267,6 +268,15 @@ export default function StatsScreen() {
     prev != null
       ? Math.round((current.totalTimeSeconds - prev.totalTimeSeconds) / 60)
       : null;
+  const timeDeltaFormatted = (() => {
+    if (timeDeltaMinutes == null) return undefined;
+    const abs = Math.abs(timeDeltaMinutes);
+    const h = Math.floor(abs / 60);
+    const m = abs % 60;
+    if (h === 0) return `${m}m`;
+    if (m === 0) return `${h}h`;
+    return `${h}h ${m}m`;
+  })();
 
   return (
     <ThemedView>
@@ -281,6 +291,7 @@ export default function StatsScreen() {
         {/* Insights strip */}
         {(completedWorkouts?.length ?? 0) > 0 && (
           <View style={styles.section}>
+            <ThemedText style={styles.sectionTitle}>Insights</ThemedText>
             <InsightsStrip
               workoutsPerWeek={insights.workoutsPerWeek}
               biggestGainLabel={insights.biggestGainLabel}
@@ -311,7 +322,7 @@ export default function StatsScreen() {
               label="Total Time"
               value={formatToHoursMinutes(current.totalTimeSeconds)}
               delta={timeDeltaMinutes}
-              deltaLabel="min"
+              deltaText={timeDeltaFormatted}
             />
             <StatsTile
               label="Avg Duration"
@@ -442,6 +453,6 @@ const styles = StyleSheet.create({
   tileGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: 10,
+    gap: 8,
   },
 });

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -12,11 +12,13 @@ import { useActivePlanQuery } from "@/hooks/useActivePlanQuery";
 import { router } from "expo-router";
 import { useActiveWorkoutStore } from "@/store/activeWorkoutStore";
 import { useSettingsQuery } from "@/hooks/useSettingsQuery";
+import { useWorkoutDurationEstimate } from "@/hooks/useWorkoutDurationEstimate";
+import { formatDurationEstimateCompact } from "@/utils/estimateWorkoutDuration";
 import {
   CompletedWorkout,
   useCompletedWorkoutsQuery,
 } from "@/hooks/useCompletedWorkoutsQuery";
-import { Workout } from "@/store/workoutStore";
+import { Workout, UserExercise } from "@/store/workoutStore";
 import Bugsnag from "@bugsnag/expo";
 import Onboarding from "@/components/Onboarding";
 import { WhatsNewModal } from "@/components/WhatsNewModal";
@@ -31,6 +33,27 @@ import {
   prioritizeScheduledWorkout,
 } from "@/utils/planHelpers";
 import { useWeeklyStreak } from "@/hooks/useWeeklyStreak";
+
+function WorkoutDurationInfo({
+  exercises,
+  countUnilateralDouble,
+  style,
+}: {
+  exercises: UserExercise[];
+  countUnilateralDouble: boolean;
+  style?: object;
+}) {
+  const { estimate } = useWorkoutDurationEstimate(
+    exercises,
+    countUnilateralDouble,
+  );
+  return (
+    <ThemedText style={style}>
+      {exercises.length} Exercises
+      {estimate ? `  ·  ~${formatDurationEstimateCompact(estimate)}` : ""}
+    </ThemedText>
+  );
+}
 
 export default function HomeScreen() {
   const [isStartingWorkout, setIsStartingWorkout] = useState(false);
@@ -53,6 +76,7 @@ export default function HomeScreen() {
 
   const weightUnit = settings?.weightUnit || "kg";
   const distanceUnit = settings?.distanceUnit || "m";
+  const countUnilateralDouble = settings?.countUnilateralDouble === "true";
   const {
     data: completedWorkouts,
     isLoading: completedWorkoutsLoading,
@@ -472,9 +496,11 @@ export default function HomeScreen() {
                         >
                           {workout.name}
                         </ThemedText>
-                        <ThemedText style={styles.exerciseInfo}>
-                          {workout.exercises.length} Exercises
-                        </ThemedText>
+                        <WorkoutDurationInfo
+                          exercises={workout.exercises}
+                          countUnilateralDouble={countUnilateralDouble}
+                          style={styles.exerciseInfo}
+                        />
                       </View>
                       <View style={styles.smallButtonGroup}>
                         <Button
@@ -498,17 +524,6 @@ export default function HomeScreen() {
                         >
                           Start
                         </Button>
-                        {/* <Button
-                        mode="outlined"
-                        onPress={() =>
-                          router.push(
-                            `/workout-details?planId=${activePlan.id}&workoutIndex=${index}`,
-                          )
-                        }
-                        labelStyle={styles.smallButtonLabel}
-                      >
-                        View
-                      </Button> */}
                       </View>
                     </View>
                   </Pressable>

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -215,9 +215,9 @@ export default function HomeScreen() {
     const completedWorkoutsList: Workout[] = [];
 
     sortedWorkouts.forEach((workout) => {
-      const target = perWorkoutTarget.get(workout.id!) ?? 0;
+      const target = perWorkoutTarget.get(workout.id!);
       const completedTimes = completedWorkoutCounts.get(workout.id!) || 0;
-      const workoutCompleted = completedTimes >= target;
+      const workoutCompleted = target !== undefined && completedTimes >= target;
 
       if (workoutCompleted) {
         completedWorkoutsList.push(workout);

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -437,17 +437,18 @@ export default function HomeScreen() {
               </ThemedText>
 
               {workoutsToDisplay.map((workout, index) => {
-                const target = perWorkoutTarget.get(workout.id!) ?? 0;
+                const target = perWorkoutTarget.get(workout.id!);
 
                 // Filter to check how many times this specific workout has been completed this week
                 const completedTimes =
                   completedWorkoutsThisPlanThisWeek?.filter(
                     (completedWorkout) =>
                       completedWorkout.workout_id === workout.id,
-                  ).length;
+                  ).length ?? 0;
 
                 // Condition to check if the workout is completed enough times
-                const workoutCompleted = completedTimes >= target;
+                const workoutCompleted =
+                  target !== undefined && completedTimes >= target;
                 const originalIndex = activePlan.workouts.findIndex(
                   (w) => w.id === workout.id,
                 );

--- a/app/(app)/(workout)/workout-session.tsx
+++ b/app/(app)/(workout)/workout-session.tsx
@@ -974,8 +974,6 @@ export default function WorkoutSessionScreen() {
       if (isFirstInSuperset) {
         stopTimer();
         void cancelRestNotifications();
-      } else if (hasNextSet) {
-        void startRestTimer(currentSet.restMinutes, currentSet.restSeconds);
       } else {
         void cancelRestNotifications();
       }

--- a/app/(app)/(workout)/workout-session.tsx
+++ b/app/(app)/(workout)/workout-session.tsx
@@ -984,7 +984,9 @@ export default function WorkoutSessionScreen() {
         setIndex: currentSetIndex,
       };
       const durationNoAnim = currentSetStartedAt
-        ? Math.round((Date.now() - new Date(currentSetStartedAt).getTime()) / 1000)
+        ? Math.round(
+            (Date.now() - new Date(currentSetStartedAt).getTime()) / 1000,
+          )
         : null;
       recordSetDuration(currentExerciseIndex, currentSetIndex, durationNoAnim);
       setCurrentSetStartedAt(null);
@@ -1049,12 +1051,19 @@ export default function WorkoutSessionScreen() {
       setIndex: currentSetIndex,
     };
     const durationAnim = currentSetStartedAt
-      ? Math.round((Date.now() - new Date(currentSetStartedAt).getTime()) / 1000)
+      ? Math.round(
+          (Date.now() - new Date(currentSetStartedAt).getTime()) / 1000,
+        )
       : null;
     recordSetDuration(currentExerciseIndex, currentSetIndex, durationAnim);
     setCurrentSetStartedAt(null);
     nextSet();
-    if (isFirstInSuperset || (hasNextSet && currentSet.restMinutes === 0 && currentSet.restSeconds === 0)) {
+    if (
+      isFirstInSuperset ||
+      (hasNextSet &&
+        currentSet.restMinutes === 0 &&
+        currentSet.restSeconds === 0)
+    ) {
       setCurrentSetStartedAt(new Date());
     }
 
@@ -1103,8 +1112,13 @@ export default function WorkoutSessionScreen() {
         (finished) => {
           "worklet";
           isTransitioning.value = false;
-          if (finished) {
-            runOnJS(afterAnimation)();
+          // Always clear the snapshot so the UI can never get permanently stuck
+          // if Reanimated fires finished=false (e.g. an animation edge case that
+          // would otherwise leave outgoingSnapshot set with the live panel
+          // hidden behind completionIncomingX = SCREEN_WIDTH).
+          runOnJS(afterAnimation)();
+          if (!finished) {
+            completionIncomingX.value = 0;
           }
         },
       );

--- a/app/(app)/(workout)/workout-session.tsx
+++ b/app/(app)/(workout)/workout-session.tsx
@@ -35,8 +35,8 @@ import Animated, {
   useAnimatedStyle,
   withTiming,
   withSpring,
-  runOnJS,
 } from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 
 // Reanimated 4: Animated.View types don't include children in strict TS
@@ -861,7 +861,7 @@ export default function WorkoutSessionScreen() {
       if (finished) {
         offsetX.value = 0;
         activeSlot.value = (activeSlot.value + 2) % 3; // -1 mod 3
-        runOnJS(onSwipePrevCommit)();
+        scheduleOnRN(onSwipePrevCommit);
       }
     });
   };
@@ -875,7 +875,7 @@ export default function WorkoutSessionScreen() {
       if (finished) {
         offsetX.value = 0;
         activeSlot.value = (activeSlot.value + 1) % 3;
-        runOnJS(onSwipeNextCommit)();
+        scheduleOnRN(onSwipeNextCommit);
       }
     });
   };
@@ -1116,7 +1116,7 @@ export default function WorkoutSessionScreen() {
           // if Reanimated fires finished=false (e.g. an animation edge case that
           // would otherwise leave outgoingSnapshot set with the live panel
           // hidden behind completionIncomingX = SCREEN_WIDTH).
-          runOnJS(afterAnimation)();
+          scheduleOnRN(afterAnimation);
           if (!finished) {
             completionIncomingX.value = 0;
           }
@@ -1169,7 +1169,7 @@ export default function WorkoutSessionScreen() {
             if (finished) {
               offsetX.value = 0;
               activeSlot.value = (activeSlot.value + 2) % 3;
-              runOnJS(onSwipePrevCommit)();
+              scheduleOnRN(onSwipePrevCommit);
             }
           },
         );
@@ -1187,7 +1187,7 @@ export default function WorkoutSessionScreen() {
             if (finished) {
               offsetX.value = 0;
               activeSlot.value = (activeSlot.value + 1) % 3;
-              runOnJS(onSwipeNextCommit)();
+              scheduleOnRN(onSwipeNextCommit);
             }
           },
         );

--- a/components/EditSetModal.tsx
+++ b/components/EditSetModal.tsx
@@ -208,7 +208,10 @@ export const EditSetModal: React.FC<EditSetModalProps> = ({
 
     if (applyToAllSets) {
       exercise?.sets.forEach((s, sIndex) => {
-        if ((s.isWarmup ?? false) === isWarmup) {
+        if (
+          (s.isWarmup ?? false) === isWarmup ||
+          (setIndex !== null && sIndex === setIndex)
+        ) {
           updateSetInExercise(workoutIndex, exerciseId, sIndex, updatedSet);
         }
       });

--- a/components/EditSetModal.tsx
+++ b/components/EditSetModal.tsx
@@ -207,9 +207,10 @@ export const EditSetModal: React.FC<EditSetModalProps> = ({
     };
 
     if (applyToAllSets) {
-      // Update all sets in the current exercise
-      exercise?.sets.forEach((_, sIndex) => {
-        updateSetInExercise(workoutIndex, exerciseId, sIndex, updatedSet);
+      exercise?.sets.forEach((s, sIndex) => {
+        if ((s.isWarmup ?? false) === isWarmup) {
+          updateSetInExercise(workoutIndex, exerciseId, sIndex, updatedSet);
+        }
       });
     } else if (setIndex !== null) {
       // Update only the selected set
@@ -415,7 +416,7 @@ export const EditSetModal: React.FC<EditSetModalProps> = ({
                   }}
                 />
                 <ThemedText style={styles.checkboxLabel}>
-                  Apply to all sets
+                  Apply to all {isWarmup ? "warmup" : "working"} sets
                 </ThemedText>
               </View>
 

--- a/components/StandaloneWorkoutListItem.tsx
+++ b/components/StandaloneWorkoutListItem.tsx
@@ -3,16 +3,24 @@ import { ThemedText } from "@/components/ThemedText";
 import { Colors } from "@/constants/Colors";
 import { Workout } from "@/store/workoutStore";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { useWorkoutDurationEstimate } from "@/hooks/useWorkoutDurationEstimate";
+import { formatDurationEstimate } from "@/utils/estimateWorkoutDuration";
 
 interface StandaloneWorkoutListItemProps {
   workout: Workout;
   onPress: () => void;
+  countUnilateralDouble?: boolean;
 }
 
 export default function StandaloneWorkoutListItem({
   workout,
   onPress,
+  countUnilateralDouble = false,
 }: StandaloneWorkoutListItemProps) {
+  const { estimate } = useWorkoutDurationEstimate(
+    workout.exercises,
+    countUnilateralDouble,
+  );
   return (
     <Pressable style={styles.container} onPress={onPress}>
       <View style={styles.imageContainer}>
@@ -31,6 +39,7 @@ export default function StandaloneWorkoutListItem({
         <ThemedText style={styles.subtitle}>
           {workout.exercises.length}{" "}
           {workout.exercises.length === 1 ? "exercise" : "exercises"}
+          {estimate ? `  ·  ~${formatDurationEstimate(estimate)}` : ""}
         </ThemedText>
       </View>
       <MaterialCommunityIcons

--- a/components/WorkoutCard.tsx
+++ b/components/WorkoutCard.tsx
@@ -57,8 +57,12 @@ export default function WorkoutCard({
   const { workouts } = useWorkoutStore();
   const { data: settings } = useSettingsQuery();
   const distanceUnit = settings?.distanceUnit || "m";
+  const countUnilateralDouble = settings?.countUnilateralDouble === "true";
   const [menuVisible, setMenuVisible] = useState<number | null>(null);
-  const { estimate } = useWorkoutDurationEstimate(workout.exercises);
+  const { estimate } = useWorkoutDurationEstimate(
+    workout.exercises,
+    countUnilateralDouble,
+  );
 
   const openMenu = (exerciseId: number) => setMenuVisible(exerciseId);
   const closeMenu = () => setMenuVisible(null);

--- a/components/WorkoutHistoryCard.tsx
+++ b/components/WorkoutHistoryCard.tsx
@@ -16,7 +16,10 @@ export default function WorkoutHistoryCard({
   excludeWarmup = false,
 }: WorkoutCardProps) {
   const setsCount = excludeWarmup
-    ? workout.exercises.reduce((t, e) => t + e.sets.filter((s) => !s.is_warmup).length, 0)
+    ? workout.exercises.reduce(
+        (t, e) => t + e.sets.filter((s) => !s.is_warmup).length,
+        0,
+      )
     : workout.total_sets_completed;
   return (
     <TouchableOpacity
@@ -33,9 +36,7 @@ export default function WorkoutHistoryCard({
         <ThemedText style={styles.workoutDuration}>
           Duration: {Math.round(workout.duration / 60)} min
         </ThemedText>
-        <ThemedText style={styles.workoutSets}>
-          Sets: {setsCount}
-        </ThemedText>
+        <ThemedText style={styles.workoutSets}>Sets: {setsCount}</ThemedText>
       </ThemedView>
     </TouchableOpacity>
   );
@@ -43,15 +44,18 @@ export default function WorkoutHistoryCard({
 
 const styles = StyleSheet.create({
   cardContainer: {
-    marginRight: 16,
+    marginRight: 8,
   },
   card: {
     width: 200,
     padding: 16,
     borderRadius: 6,
     backgroundColor: Colors.dark.cardBackground,
-    boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.2)",
-    elevation: 3, // For Android shadow
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    elevation: 4, // For Android shadow
   },
   workoutName: {
     fontSize: 16,

--- a/components/stats/InsightsStrip.tsx
+++ b/components/stats/InsightsStrip.tsx
@@ -33,7 +33,7 @@ export const InsightsStrip: React.FC<InsightsStripProps> = ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const containerRef = useRef<any>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const gainPillRef = useRef<any>(null);
+  const pillRefs = useRef<Record<string, any>>({});
 
   useEffect(
     () => () => {
@@ -42,15 +42,16 @@ export const InsightsStrip: React.FC<InsightsStripProps> = ({
     [],
   );
 
-  const showTooltip = (text: string) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const showTooltip = (text: string, pillRef: any) => {
     if (dismissTimer.current) clearTimeout(dismissTimer.current);
     setTooltipHalfWidth(0);
 
-    gainPillRef.current?.measureInWindow(
+    pillRef?.measureInWindow(
       (pillX: number, _pillY: number, pillWidth: number) => {
         containerRef.current?.measureInWindow((containerX: number) => {
           setTooltipLeft(pillX - containerX + pillWidth / 2);
-          setTooltipText(text);
+          setTooltipText(text + " 1RM");
         });
       },
     );
@@ -82,12 +83,23 @@ export const InsightsStrip: React.FC<InsightsStripProps> = ({
 
   if (pills.length === 0) return null;
 
-  const renderPill = (pill: InsightPill, i: number) => (
+  const renderPill = (pill: InsightPill) => (
     <Pressable
-      key={i}
-      ref={pill.tooltip ? gainPillRef : undefined}
+      key={pill.label}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ref={
+        pill.tooltip
+          ? (el: any) => {
+              pillRefs.current[pill.label] = el;
+            }
+          : undefined
+      }
       style={styles.pill}
-      onPress={pill.tooltip ? () => showTooltip(pill.tooltip!) : undefined}
+      onPress={
+        pill.tooltip
+          ? () => showTooltip(pill.tooltip!, pillRefs.current[pill.label])
+          : undefined
+      }
     >
       <View style={styles.pillLabelRow}>
         <ThemedText style={styles.pillLabel}>{pill.label}</ThemedText>
@@ -142,7 +154,7 @@ export const InsightsStrip: React.FC<InsightsStripProps> = ({
         <View style={styles.grid} onLayout={onLayout}>
           {rows.map((row, ri) => (
             <View key={ri} style={styles.row}>
-              {row.map((pill, i) => renderPill(pill, ri * 2 + i))}
+              {row.map((pill) => renderPill(pill))}
             </View>
           ))}
         </View>
@@ -153,7 +165,7 @@ export const InsightsStrip: React.FC<InsightsStripProps> = ({
           contentContainerStyle={styles.strip}
           onLayout={onLayout}
         >
-          {pills.map((pill, i) => renderPill(pill, i))}
+          {pills.map((pill) => renderPill(pill))}
         </ScrollView>
       )}
     </View>

--- a/components/stats/InsightsStrip.tsx
+++ b/components/stats/InsightsStrip.tsx
@@ -51,7 +51,7 @@ export const InsightsStrip: React.FC<InsightsStripProps> = ({
       (pillX: number, _pillY: number, pillWidth: number) => {
         containerRef.current?.measureInWindow((containerX: number) => {
           setTooltipLeft(pillX - containerX + pillWidth / 2);
-          setTooltipText(text + " 1RM");
+          setTooltipText(text);
         });
       },
     );
@@ -71,7 +71,7 @@ export const InsightsStrip: React.FC<InsightsStripProps> = ({
     pills.push({
       label: "Best gain",
       value: biggestGainValue,
-      tooltip: biggestGainLabel,
+      tooltip: `${biggestGainLabel} 1RM`,
     });
   }
   if (topBodyPart) {

--- a/components/stats/InsightsStrip.tsx
+++ b/components/stats/InsightsStrip.tsx
@@ -82,6 +82,38 @@ export const InsightsStrip: React.FC<InsightsStripProps> = ({
 
   if (pills.length === 0) return null;
 
+  const renderPill = (pill: InsightPill, i: number) => (
+    <Pressable
+      key={i}
+      ref={pill.tooltip ? gainPillRef : undefined}
+      style={styles.pill}
+      onPress={pill.tooltip ? () => showTooltip(pill.tooltip!) : undefined}
+    >
+      <View style={styles.pillLabelRow}>
+        <ThemedText style={styles.pillLabel}>{pill.label}</ThemedText>
+        {pill.tooltip ? (
+          <ThemedText style={styles.infoIcon}>{"ⓘ"}</ThemedText>
+        ) : null}
+      </View>
+      <ThemedText style={styles.pillValue}>{pill.value}</ThemedText>
+    </Pressable>
+  );
+
+  const useGrid = pills.length >= 4;
+
+  const rows: InsightPill[][] = [];
+  if (useGrid) {
+    for (let i = 0; i < pills.length; i += 2) {
+      rows.push(pills.slice(i, i + 2));
+    }
+  }
+
+  const onLayout = ({
+    nativeEvent,
+  }: {
+    nativeEvent: { layout: { height: number } };
+  }) => setStripHeight(nativeEvent.layout.height);
+
   return (
     <View ref={containerRef}>
       {tooltipText ? (
@@ -106,35 +138,24 @@ export const InsightsStrip: React.FC<InsightsStripProps> = ({
           <ThemedText style={styles.tooltipText}>{tooltipText}</ThemedText>
         </View>
       ) : null}
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={styles.strip}
-        onLayout={({
-          nativeEvent,
-        }: {
-          nativeEvent: { layout: { height: number } };
-        }) => setStripHeight(nativeEvent.layout.height)}
-      >
-        {pills.map((pill, i) => (
-          <Pressable
-            key={i}
-            ref={pill.tooltip ? gainPillRef : undefined}
-            style={styles.pill}
-            onPress={
-              pill.tooltip ? () => showTooltip(pill.tooltip!) : undefined
-            }
-          >
-            <View style={styles.pillLabelRow}>
-              <ThemedText style={styles.pillLabel}>{pill.label}</ThemedText>
-              {pill.tooltip ? (
-                <ThemedText style={styles.infoIcon}>{"ⓘ"}</ThemedText>
-              ) : null}
+      {useGrid ? (
+        <View style={styles.grid} onLayout={onLayout}>
+          {rows.map((row, ri) => (
+            <View key={ri} style={styles.row}>
+              {row.map((pill, i) => renderPill(pill, ri * 2 + i))}
             </View>
-            <ThemedText style={styles.pillValue}>{pill.value}</ThemedText>
-          </Pressable>
-        ))}
-      </ScrollView>
+          ))}
+        </View>
+      ) : (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.strip}
+          onLayout={onLayout}
+        >
+          {pills.map((pill, i) => renderPill(pill, i))}
+        </ScrollView>
+      )}
     </View>
   );
 };
@@ -144,12 +165,20 @@ const styles = StyleSheet.create({
     paddingVertical: 4,
     gap: 10,
   },
+  grid: {
+    gap: 8,
+    paddingVertical: 4,
+  },
+  row: {
+    flexDirection: "row",
+    gap: 8,
+  },
   pill: {
+    flex: 1,
     backgroundColor: Colors.dark.cardBackground,
     borderRadius: 6,
     paddingVertical: 10,
     paddingHorizontal: 14,
-    minWidth: 110,
     alignItems: "center",
     borderWidth: 1,
     borderColor: Colors.dark.tint + "40",

--- a/components/stats/StatsTile.tsx
+++ b/components/stats/StatsTile.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
 import { Card } from "react-native-paper";
 import { ThemedText } from "@/components/ThemedText";
 import { Colors } from "@/constants/Colors";
@@ -11,7 +11,10 @@ interface StatsTileProps {
   deltaLabel?: string;
 }
 
-const DeltaText: React.FC<{ delta: number; label?: string }> = ({ delta, label }) => {
+const DeltaText: React.FC<{ delta: number; label?: string }> = ({
+  delta,
+  label,
+}) => {
   const isPositive = delta > 0;
   const isNeutral = delta === 0;
   const color = isNeutral
@@ -36,16 +39,14 @@ export const StatsTile: React.FC<StatsTileProps> = ({
     <Card style={styles.card}>
       <ThemedText style={styles.value}>{value}</ThemedText>
       <ThemedText style={styles.label}>{label}</ThemedText>
-      {delta != null && (
-        <DeltaText delta={delta} label={deltaLabel} />
-      )}
+      {delta != null && <DeltaText delta={delta} label={deltaLabel} />}
     </Card>
   );
 };
 
 const styles = StyleSheet.create({
   card: {
-    width: "48%",
+    flex: 1,
     paddingVertical: 14,
     paddingHorizontal: 12,
     borderRadius: 6,

--- a/components/stats/StatsTile.tsx
+++ b/components/stats/StatsTile.tsx
@@ -9,12 +9,14 @@ interface StatsTileProps {
   value: string;
   delta?: number | null;
   deltaLabel?: string;
+  deltaText?: string;
 }
 
-const DeltaText: React.FC<{ delta: number; label?: string }> = ({
-  delta,
-  label,
-}) => {
+const DeltaText: React.FC<{
+  delta: number;
+  label?: string;
+  deltaText?: string;
+}> = ({ delta, label, deltaText }) => {
   const isPositive = delta > 0;
   const isNeutral = delta === 0;
   const color = isNeutral
@@ -24,7 +26,8 @@ const DeltaText: React.FC<{ delta: number; label?: string }> = ({
       : Colors.dark.highlight;
   const prefix = isNeutral ? "─" : isPositive ? "▲" : "▼";
   const absVal = Math.abs(delta);
-  const text = `${prefix} ${label ? `${absVal}${label}` : absVal}`;
+  const formatted = deltaText ?? (label ? `${absVal}${label}` : absVal);
+  const text = `${prefix} ${formatted}`;
 
   return <ThemedText style={[styles.delta, { color }]}>{text}</ThemedText>;
 };
@@ -34,19 +37,23 @@ export const StatsTile: React.FC<StatsTileProps> = ({
   value,
   delta,
   deltaLabel,
+  deltaText,
 }) => {
   return (
     <Card style={styles.card}>
       <ThemedText style={styles.value}>{value}</ThemedText>
       <ThemedText style={styles.label}>{label}</ThemedText>
-      {delta != null && <DeltaText delta={delta} label={deltaLabel} />}
+      {delta != null && (
+        <DeltaText delta={delta} label={deltaLabel} deltaText={deltaText} />
+      )}
     </Card>
   );
 };
 
 const styles = StyleSheet.create({
   card: {
-    flex: 1,
+    flexBasis: "47%",
+    flexGrow: 1,
     paddingVertical: 14,
     paddingHorizontal: 12,
     borderRadius: 6,

--- a/components/stats/WorkoutHistorySection.tsx
+++ b/components/stats/WorkoutHistorySection.tsx
@@ -17,7 +17,9 @@ export const WorkoutHistorySection: React.FC<WorkoutHistorySectionProps> = ({
 }) => {
   if (completedWorkouts.length === 0) {
     return (
-      <ThemedText>No workouts completed yet. Start your first workout!</ThemedText>
+      <ThemedText>
+        No workouts completed yet. Start your first workout!
+      </ThemedText>
     );
   }
 
@@ -26,7 +28,11 @@ export const WorkoutHistorySection: React.FC<WorkoutHistorySectionProps> = ({
       <FlatList
         data={completedWorkouts}
         renderItem={({ item }: { item: CompletedWorkout }) => (
-          <WorkoutHistoryCard workout={item} onPress={() => onWorkoutPress(item.id)} excludeWarmup={excludeWarmup} />
+          <WorkoutHistoryCard
+            workout={item}
+            onPress={() => onWorkoutPress(item.id)}
+            excludeWarmup={excludeWarmup}
+          />
         )}
         keyExtractor={(item: CompletedWorkout) => item.id.toString()}
         horizontal

--- a/hooks/useCreatePlan.ts
+++ b/hooks/useCreatePlan.ts
@@ -18,14 +18,8 @@ export const useCreatePlan = (existingPlan?: Plan) => {
   const [planName, setPlanName] = useState("");
   const [isError, setIsError] = useState(false);
 
-  const {
-    workouts,
-    clearWorkouts,
-    planImageUrl,
-    setPlanImageUrl,
-    planSchedule,
-    clearPlanSchedule,
-  } = useWorkoutStore();
+  const { workouts, planImageUrl, setPlanImageUrl, planSchedule, clearDraft } =
+    useWorkoutStore();
 
   useEffect(() => {
     if (existingPlan) {
@@ -120,8 +114,7 @@ export const useCreatePlan = (existingPlan?: Plan) => {
       localError = true;
     } finally {
       if (localPlanSaved && !localError) {
-        clearWorkouts();
-        clearPlanSchedule();
+        clearDraft();
         queryClient.invalidateQueries({ queryKey: ["plans"] });
         queryClient.invalidateQueries({ queryKey: ["activePlan"] });
       }

--- a/hooks/useWorkoutDurationEstimate.ts
+++ b/hooks/useWorkoutDurationEstimate.ts
@@ -8,7 +8,10 @@ import {
 import type { UserExercise } from "@/store/workoutStore";
 import Bugsnag from "@bugsnag/expo";
 
-export function useWorkoutDurationEstimate(exercises: UserExercise[]): {
+export function useWorkoutDurationEstimate(
+  exercises: UserExercise[],
+  countUnilateralDouble = false,
+): {
   estimate: DurationEstimate | null;
   isLoading: boolean;
 } {
@@ -33,8 +36,12 @@ export function useWorkoutDurationEstimate(exercises: UserExercise[]): {
 
   const estimate = useMemo(() => {
     if (exercises.length === 0) return null;
-    return computeWorkoutDurationEstimate(exercises, data ?? {});
-  }, [exercises, data]);
+    return computeWorkoutDurationEstimate(
+      exercises,
+      data ?? {},
+      countUnilateralDouble,
+    );
+  }, [exercises, data, countUnilateralDouble]);
 
   return { estimate, isLoading };
 }

--- a/store/activeWorkoutStore.ts
+++ b/store/activeWorkoutStore.ts
@@ -73,7 +73,9 @@ interface ActiveWorkoutStore {
   timerRunning: boolean;
   timerExpiry: Date | null;
   currentSetStartedAt: Date | null;
-  setDurations: { [exerciseIndex: number]: { [setIndex: number]: number | null } };
+  setDurations: {
+    [exerciseIndex: number]: { [setIndex: number]: number | null };
+  };
   appendedExerciseIndices: number[];
   appendExercise: (exercise: UserExercise) => void;
   setWorkout: (
@@ -118,7 +120,11 @@ interface ActiveWorkoutStore {
   startTimer: (expiry: Date) => void;
   stopTimer: () => void;
   setCurrentSetStartedAt: (date: Date | null) => void;
-  recordSetDuration: (exerciseIndex: number, setIndex: number, duration: number | null) => void;
+  recordSetDuration: (
+    exerciseIndex: number,
+    setIndex: number,
+    duration: number | null,
+  ) => void;
   clearPersistedStore: () => void;
   resumeWorkout: () => void;
   isWorkoutInProgress: () => boolean;
@@ -393,9 +399,23 @@ const useActiveWorkoutStore = create<ActiveWorkoutStore>()(
               }
 
               if (nextExerciseIndex < workout.exercises.length) {
+                const nextExTotalSets =
+                  workout.exercises[nextExerciseIndex].sets.length;
+                const nextExCompleted =
+                  updatedCompletedSets[nextExerciseIndex] || {};
+                let firstUncompleted = 0;
+                for (let s = 0; s < nextExTotalSets; s++) {
+                  if (!nextExCompleted[s]) {
+                    firstUncompleted = s;
+                    break;
+                  }
+                }
                 return {
                   currentExerciseIndex: nextExerciseIndex,
-                  currentSetIndices: updatedSetIndices,
+                  currentSetIndices: {
+                    ...updatedSetIndices,
+                    [nextExerciseIndex]: firstUncompleted,
+                  },
                   completedSets: updatedCompletedSets,
                   weightAndReps: updatedWeightAndReps,
                 };
@@ -513,9 +533,21 @@ const useActiveWorkoutStore = create<ActiveWorkoutStore>()(
                 totalSets;
 
             if (!isExerciseCompleted) {
+              const nextExCompleted =
+                updatedCompletedSets[nextExerciseIndex] || {};
+              let firstUncompleted = 0;
+              for (let s = 0; s < totalSets; s++) {
+                if (!nextExCompleted[s]) {
+                  firstUncompleted = s;
+                  break;
+                }
+              }
               return {
                 currentExerciseIndex: nextExerciseIndex,
-                currentSetIndices: updatedSetIndices,
+                currentSetIndices: {
+                  ...updatedSetIndices,
+                  [nextExerciseIndex]: firstUncompleted,
+                },
                 completedSets: updatedCompletedSets,
               };
             }

--- a/store/activeWorkoutStore.ts
+++ b/store/activeWorkoutStore.ts
@@ -390,10 +390,10 @@ const useActiveWorkoutStore = create<ActiveWorkoutStore>()(
               while (nextExerciseIndex < workout.exercises.length) {
                 const totalSets =
                   workout.exercises[nextExerciseIndex].sets.length;
-                const isComplete =
-                  updatedCompletedSets[nextExerciseIndex] &&
-                  Object.keys(updatedCompletedSets[nextExerciseIndex])
-                    .length === totalSets;
+                const completedCount = Object.values(
+                  updatedCompletedSets[nextExerciseIndex] || {},
+                ).filter((v) => v === true).length;
+                const isComplete = completedCount === totalSets;
                 if (!isComplete) break;
                 nextExerciseIndex++;
               }
@@ -527,10 +527,10 @@ const useActiveWorkoutStore = create<ActiveWorkoutStore>()(
           let nextExerciseIndex = currentExerciseIndex + 1;
           while (nextExerciseIndex < workout.exercises.length) {
             const totalSets = workout.exercises[nextExerciseIndex].sets.length;
-            const isExerciseCompleted =
-              updatedCompletedSets[nextExerciseIndex] &&
-              Object.keys(updatedCompletedSets[nextExerciseIndex]).length ===
-                totalSets;
+            const completedCount = Object.values(
+              updatedCompletedSets[nextExerciseIndex] || {},
+            ).filter((v) => v === true).length;
+            const isExerciseCompleted = completedCount === totalSets;
 
             if (!isExerciseCompleted) {
               const nextExCompleted =

--- a/store/workoutStore.ts
+++ b/store/workoutStore.ts
@@ -33,6 +33,13 @@ export interface Workout {
   exercises: UserExercise[];
 }
 
+export interface DraftEntry {
+  workouts: Workout[];
+  planImageUrl?: string;
+  planSchedule?: Record<number, number>;
+  draftName?: string;
+}
+
 interface WorkoutStore {
   workouts: Workout[];
   newExerciseId: number | null;
@@ -90,13 +97,10 @@ interface WorkoutStore {
   setPlanSchedule: (schedule: Record<number, number>) => void;
   clearPlanSchedule: () => void;
   syncScheduleOnRemoveWorkout: (removedIndex: number) => void;
-  // Draft persistence metadata
-  draftContext: "plan" | "standalone" | null;
-  draftId: number | null;
-  draftName: string;
-  setDraftContext: (context: "plan" | "standalone" | null) => void;
-  setDraftId: (id: number | null) => void;
-  setDraftName: (name: string) => void;
+  // Draft persistence — one slot per context:id pair
+  drafts: Record<string, DraftEntry>;
+  saveDraftEntry: (key: string, entry: DraftEntry) => void;
+  clearDraftEntry: (key: string) => void;
   clearDraft: () => void;
 }
 
@@ -502,32 +506,31 @@ const useWorkoutStore = create<WorkoutStore>()(
           return { planSchedule: updated };
         }),
 
-      draftContext: null,
-      draftId: null,
-      draftName: "",
-      setDraftContext: (context) => set({ draftContext: context }),
-      setDraftId: (id) => set({ draftId: id }),
-      setDraftName: (name) => set({ draftName: name }),
+      drafts: {},
+      saveDraftEntry: (key, entry) =>
+        set((state) => ({ drafts: { ...state.drafts, [key]: entry } })),
+      clearDraftEntry: (key) =>
+        set((state) => {
+          const { [key]: _removed, ...rest } = state.drafts;
+          return { drafts: rest };
+        }),
       clearDraft: () =>
         set({
           workouts: [],
           planImageUrl: DEFAULT_PLAN_IMAGE_URL,
           planSchedule: {},
-          draftContext: null,
-          draftId: null,
-          draftName: "",
         }),
     }),
     {
       name: "workout-draft-store",
+      version: 1,
+      migrate: (persistedState, version) => {
+        if (version < 1) return { drafts: {} };
+        return persistedState as { drafts: Record<string, DraftEntry> };
+      },
       storage: createJSONStorage(() => AsyncStorage),
       partialize: (state) => ({
-        workouts: state.workouts,
-        planImageUrl: state.planImageUrl,
-        planSchedule: state.planSchedule,
-        draftContext: state.draftContext,
-        draftId: state.draftId,
-        draftName: state.draftName,
+        drafts: state.drafts,
       }),
     },
   ),

--- a/store/workoutStore.ts
+++ b/store/workoutStore.ts
@@ -62,6 +62,12 @@ interface WorkoutStore {
     exerciseId: number,
     set: Set,
   ) => void;
+  insertSetAtExercise: (
+    workoutIndex: number,
+    exerciseId: number,
+    atIndex: number,
+    set: Set,
+  ) => void;
   updateSetInExercise: (
     workoutIndex: number,
     exerciseId: number,
@@ -285,6 +291,43 @@ const useWorkoutStore = create<WorkoutStore>()(
                   ...exercise,
                   sets: [...exercise.sets, { ...lastSet }],
                 };
+              }
+              return exercise;
+            });
+            return { ...w, exercises };
+          });
+          return { workouts };
+        });
+      },
+      insertSetAtExercise: (workoutIndex, exerciseId, atIndex, newSet) => {
+        set((state) => {
+          const workout = state.workouts[workoutIndex];
+          if (!workout) return state;
+          const targetExercise = workout.exercises.find(
+            (e) => e.exercise_id === exerciseId,
+          );
+          const partner = targetExercise?.supersetGroupId
+            ? workout.exercises.find(
+                (e) =>
+                  e.exercise_id !== exerciseId &&
+                  e.supersetGroupId === targetExercise.supersetGroupId,
+              )
+            : null;
+
+          const workouts = state.workouts.map((w, wIndex) => {
+            if (wIndex !== workoutIndex) return w;
+            const exercises = w.exercises.map((exercise) => {
+              if (exercise.exercise_id === exerciseId) {
+                const sets = [...exercise.sets];
+                sets.splice(atIndex, 0, newSet);
+                return { ...exercise, sets };
+              }
+              if (partner && exercise.exercise_id === partner.exercise_id) {
+                const lastSet =
+                  exercise.sets[exercise.sets.length - 1] ?? newSet;
+                const sets = [...exercise.sets];
+                sets.splice(atIndex, 0, { ...lastSet });
+                return { ...exercise, sets };
               }
               return exercise;
             });

--- a/store/workoutStore.ts
+++ b/store/workoutStore.ts
@@ -1,6 +1,11 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 import { Exercise } from "@/utils/database";
 import * as Crypto from "expo-crypto";
+
+export const DEFAULT_PLAN_IMAGE_URL =
+  "https://images.unsplash.com/photo-1581009146145-b5ef050c2e1e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
 
 export interface Set {
   repsMin: number | undefined;
@@ -79,346 +84,404 @@ interface WorkoutStore {
   setPlanSchedule: (schedule: Record<number, number>) => void;
   clearPlanSchedule: () => void;
   syncScheduleOnRemoveWorkout: (removedIndex: number) => void;
+  // Draft persistence metadata
+  draftContext: "plan" | "standalone" | null;
+  draftId: number | null;
+  draftName: string;
+  setDraftContext: (context: "plan" | "standalone" | null) => void;
+  setDraftId: (id: number | null) => void;
+  setDraftName: (name: string) => void;
+  clearDraft: () => void;
 }
 
-const useWorkoutStore = create<WorkoutStore>((set) => ({
-  workouts: [],
-  newExerciseId: null,
-  setNewExerciseId: (id) => set((state) => ({ ...state, newExerciseId: id })),
-  planImageUrl:
-    "https://images.unsplash.com/photo-1581009146145-b5ef050c2e1e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", // Default image URL
-  setPlanImageUrl: (url) => set({ planImageUrl: url }),
-  setWorkouts: (workouts) => set({ workouts }),
-  clearWorkouts: () => set({ workouts: [] }),
-  addWorkout: (workout) =>
-    set((state) => ({ ...state, workouts: [...state.workouts, workout] })),
-  removeWorkout: (index) =>
-    set((state) => {
-      const workouts = state.workouts.filter((_, i) => i !== index);
-      const planSchedule: Record<number, number> = {};
-      for (const [day, idx] of Object.entries(state.planSchedule)) {
-        const workoutIdx = Number(idx);
-        if (workoutIdx === index) continue;
-        planSchedule[Number(day)] =
-          workoutIdx > index ? workoutIdx - 1 : workoutIdx;
-      }
-      return { workouts, planSchedule };
-    }),
-  reorderWorkouts: (fromIndex, toIndex) =>
-    set((state) => {
-      const { length } = state.workouts;
-      if (
-        fromIndex === toIndex ||
-        fromIndex < 0 ||
-        fromIndex >= length ||
-        toIndex < 0 ||
-        toIndex >= length
-      ) {
-        return state;
-      }
-      const updated = [...state.workouts];
-      const [moved] = updated.splice(fromIndex, 1);
-      updated.splice(toIndex, 0, moved);
-
-      // Remap schedule day → index entries to reflect the new workout order
-      const remappedSchedule: Record<number, number> = {};
-      for (const [day, idx] of Object.entries(state.planSchedule)) {
-        const dayKey = Number(day);
-        const workoutIdx = Number(idx);
-        if (workoutIdx === fromIndex) {
-          remappedSchedule[dayKey] = toIndex;
-        } else if (
-          fromIndex < toIndex &&
-          workoutIdx > fromIndex &&
-          workoutIdx <= toIndex
-        ) {
-          remappedSchedule[dayKey] = workoutIdx - 1;
-        } else if (
-          fromIndex > toIndex &&
-          workoutIdx >= toIndex &&
-          workoutIdx < fromIndex
-        ) {
-          remappedSchedule[dayKey] = workoutIdx + 1;
-        } else {
-          remappedSchedule[dayKey] = workoutIdx;
-        }
-      }
-
-      return { ...state, workouts: updated, planSchedule: remappedSchedule };
-    }),
-  changeWorkoutName: (index, name) =>
-    set((state) => ({
-      ...state,
-      workouts: state.workouts.map((w, i) => {
-        if (i === index) {
-          return { ...w, name };
-        }
-        return w;
-      }),
-    })),
-  addExercise: (index, exercise) => {
-    set((state) => ({
-      ...state,
-      workouts: state.workouts.map((w, i) => {
-        if (i === index) {
-          return { ...w, exercises: [...w.exercises, exercise] };
-        }
-        return w;
-      }),
-    }));
-  },
-  removeExercise: (index, exerciseId) =>
-    set((state) => ({
-      ...state,
-      workouts: state.workouts.map((w, i) => {
-        if (i === index) {
-          return {
-            ...w,
-            exercises: w.exercises.filter((e) => e.exercise_id !== exerciseId),
-          };
-        }
-        return w;
-      }),
-    })),
-  replaceExercise: (
-    workoutIndex,
-    exerciseIndex,
-    newExercise,
-    defaultSets,
-    defaultTimeSets,
-  ) => {
-    set((state) => {
-      const updatedWorkouts = [...state.workouts];
-      const workout = updatedWorkouts[workoutIndex];
-
-      if (!workout || !workout.exercises[exerciseIndex]) {
-        return { workouts: updatedWorkouts };
-      }
-
-      const oldExercise = workout.exercises[exerciseIndex];
-      let oldTrackingType = oldExercise.tracking_type;
-      let newTrackingType = newExercise.tracking_type;
-      if (oldTrackingType === "" || oldTrackingType === null) {
-        oldTrackingType = "weight";
-      }
-      if (newTrackingType === "" || newTrackingType === null) {
-        newTrackingType = "weight";
-      }
-
-      if (oldTrackingType === newTrackingType) {
-        // Same tracking type: carry over old sets
-        newExercise.sets = oldExercise.sets;
-      } else if (newTrackingType === "time") {
-        newExercise.sets = defaultTimeSets;
-      } else if (
-        (newTrackingType === "assisted" && oldTrackingType === "weight") ||
-        (newTrackingType === "weight" && oldTrackingType === "assisted")
-      ) {
-        newExercise.sets = oldExercise.sets;
-      } else {
-        newExercise.sets = defaultSets;
-      }
-
-      const updatedExercises = [...workout.exercises];
-      updatedExercises[exerciseIndex] = newExercise;
-      updatedWorkouts[workoutIndex] = {
-        ...workout,
-        exercises: updatedExercises,
-      };
-
-      return { workouts: updatedWorkouts };
-    });
-  },
-  addSetToExercise: (workoutIndex: number, exerciseId: number, newSet: Set) => {
-    set((state) => {
-      const workout = state.workouts[workoutIndex];
-      if (!workout) return state;
-
-      const targetExercise = workout.exercises.find(
-        (e) => e.exercise_id === exerciseId,
-      );
-      const supersetGroupId = targetExercise?.supersetGroupId;
-      const partner = supersetGroupId
-        ? workout.exercises.find(
-            (e) =>
-              e.exercise_id !== exerciseId &&
-              e.supersetGroupId === supersetGroupId,
-          )
-        : null;
-
-      const workouts = state.workouts.map((w, wIndex) => {
-        if (wIndex !== workoutIndex) return w;
-        const exercises = w.exercises.map((exercise) => {
-          if (exercise.exercise_id === exerciseId) {
-            return { ...exercise, sets: [...exercise.sets, newSet] };
+const useWorkoutStore = create<WorkoutStore>()(
+  persist(
+    (set) => ({
+      workouts: [],
+      newExerciseId: null,
+      setNewExerciseId: (id) =>
+        set((state) => ({ ...state, newExerciseId: id })),
+      planImageUrl: DEFAULT_PLAN_IMAGE_URL,
+      setPlanImageUrl: (url) => set({ planImageUrl: url }),
+      setWorkouts: (workouts) => set({ workouts }),
+      clearWorkouts: () => set({ workouts: [] }),
+      addWorkout: (workout) =>
+        set((state) => ({ ...state, workouts: [...state.workouts, workout] })),
+      removeWorkout: (index) =>
+        set((state) => {
+          const workouts = state.workouts.filter((_, i) => i !== index);
+          const planSchedule: Record<number, number> = {};
+          for (const [day, idx] of Object.entries(state.planSchedule)) {
+            const workoutIdx = Number(idx);
+            if (workoutIdx === index) continue;
+            planSchedule[Number(day)] =
+              workoutIdx > index ? workoutIdx - 1 : workoutIdx;
           }
-          // Mirror to superset partner: copy partner's last set as template
-          if (partner && exercise.exercise_id === partner.exercise_id) {
-            const lastSet = exercise.sets[exercise.sets.length - 1] ?? newSet;
-            return { ...exercise, sets: [...exercise.sets, { ...lastSet }] };
+          return { workouts, planSchedule };
+        }),
+      reorderWorkouts: (fromIndex, toIndex) =>
+        set((state) => {
+          const { length } = state.workouts;
+          if (
+            fromIndex === toIndex ||
+            fromIndex < 0 ||
+            fromIndex >= length ||
+            toIndex < 0 ||
+            toIndex >= length
+          ) {
+            return state;
           }
-          return exercise;
-        });
-        return { ...w, exercises };
-      });
-      return { workouts };
-    });
-  },
-  updateSetInExercise: (
-    workoutIndex: number,
-    exerciseId: number,
-    setIndex: number,
-    updatedSet: Set,
-  ) => {
-    set((state) => {
-      const workouts = state.workouts.map((workout, wIndex) => {
-        if (wIndex !== workoutIndex) {
-          return workout;
-        }
-        const exercises = workout.exercises.map((exercise) => {
-          if (exercise.exercise_id !== exerciseId) {
-            return exercise;
-          }
-          const sets = exercise.sets.map((set, sIndex) => {
-            if (sIndex !== setIndex) {
-              return set;
+          const updated = [...state.workouts];
+          const [moved] = updated.splice(fromIndex, 1);
+          updated.splice(toIndex, 0, moved);
+
+          // Remap schedule day → index entries to reflect the new workout order
+          const remappedSchedule: Record<number, number> = {};
+          for (const [day, idx] of Object.entries(state.planSchedule)) {
+            const dayKey = Number(day);
+            const workoutIdx = Number(idx);
+            if (workoutIdx === fromIndex) {
+              remappedSchedule[dayKey] = toIndex;
+            } else if (
+              fromIndex < toIndex &&
+              workoutIdx > fromIndex &&
+              workoutIdx <= toIndex
+            ) {
+              remappedSchedule[dayKey] = workoutIdx - 1;
+            } else if (
+              fromIndex > toIndex &&
+              workoutIdx >= toIndex &&
+              workoutIdx < fromIndex
+            ) {
+              remappedSchedule[dayKey] = workoutIdx + 1;
+            } else {
+              remappedSchedule[dayKey] = workoutIdx;
             }
-            return updatedSet;
-          });
+          }
+
           return {
-            ...exercise,
-            sets,
+            ...state,
+            workouts: updated,
+            planSchedule: remappedSchedule,
           };
-        });
-        return {
-          ...workout,
-          exercises,
-        };
-      });
-      return { workouts };
-    });
-  },
-  removeSetFromExercise: (
-    workoutIndex: number,
-    exerciseId: number,
-    setIndex: number,
-  ) => {
-    set((state) => {
-      const workout = state.workouts[workoutIndex];
-      if (!workout) return state;
+        }),
+      changeWorkoutName: (index, name) =>
+        set((state) => ({
+          ...state,
+          workouts: state.workouts.map((w, i) => {
+            if (i === index) {
+              return { ...w, name };
+            }
+            return w;
+          }),
+        })),
+      addExercise: (index, exercise) => {
+        set((state) => ({
+          ...state,
+          workouts: state.workouts.map((w, i) => {
+            if (i === index) {
+              return { ...w, exercises: [...w.exercises, exercise] };
+            }
+            return w;
+          }),
+        }));
+      },
+      removeExercise: (index, exerciseId) =>
+        set((state) => ({
+          ...state,
+          workouts: state.workouts.map((w, i) => {
+            if (i === index) {
+              return {
+                ...w,
+                exercises: w.exercises.filter(
+                  (e) => e.exercise_id !== exerciseId,
+                ),
+              };
+            }
+            return w;
+          }),
+        })),
+      replaceExercise: (
+        workoutIndex,
+        exerciseIndex,
+        newExercise,
+        defaultSets,
+        defaultTimeSets,
+      ) => {
+        set((state) => {
+          const updatedWorkouts = [...state.workouts];
+          const workout = updatedWorkouts[workoutIndex];
 
-      const targetExercise = workout.exercises.find(
-        (e) => e.exercise_id === exerciseId,
-      );
-      const supersetGroupId = targetExercise?.supersetGroupId;
-      const partner = supersetGroupId
-        ? workout.exercises.find(
-            (e) =>
-              e.exercise_id !== exerciseId &&
-              e.supersetGroupId === supersetGroupId,
-          )
-        : null;
-
-      const workouts = state.workouts.map((w, wIndex) => {
-        if (wIndex !== workoutIndex) {
-          return w;
-        }
-        const exercises = w.exercises.map((exercise) => {
-          if (exercise.exercise_id === exerciseId) {
-            // Must keep at least 1 set
-            if (exercise.sets.length <= 1) return exercise;
-            return {
-              ...exercise,
-              sets: exercise.sets.filter((_, sIndex) => sIndex !== setIndex),
-            };
+          if (!workout || !workout.exercises[exerciseIndex]) {
+            return { workouts: updatedWorkouts };
           }
-          // Mirror removal to superset partner
-          if (partner && exercise.exercise_id === partner.exercise_id) {
-            if (exercise.sets.length <= 1) return exercise;
-            return {
-              ...exercise,
-              sets: exercise.sets.filter((_, sIndex) => sIndex !== setIndex),
-            };
+
+          const oldExercise = workout.exercises[exerciseIndex];
+          let oldTrackingType = oldExercise.tracking_type;
+          let newTrackingType = newExercise.tracking_type;
+          if (oldTrackingType === "" || oldTrackingType === null) {
+            oldTrackingType = "weight";
           }
-          return exercise;
-        });
-        return {
-          ...w,
-          exercises,
-        };
-      });
-      return { workouts };
-    });
-  },
-  createSuperset: (workoutIndex, exerciseIndex, newExercise) =>
-    set((state) => {
-      const groupId = Crypto.randomUUID();
-      const updatedWorkouts = state.workouts.map((w, i) => {
-        if (i !== workoutIndex) return w;
-        const exercises = [...w.exercises];
-        exercises[exerciseIndex] = {
-          ...exercises[exerciseIndex],
-          supersetGroupId: groupId,
-        };
-        exercises.splice(exerciseIndex + 1, 0, {
-          ...newExercise,
-          supersetGroupId: groupId,
-        });
-        return { ...w, exercises };
-      });
-      return { workouts: updatedWorkouts };
-    }),
+          if (newTrackingType === "" || newTrackingType === null) {
+            newTrackingType = "weight";
+          }
 
-  removeFromSuperset: (workoutIndex, exerciseIndex) =>
-    set((state) => {
-      const updatedWorkouts = state.workouts.map((w, i) => {
-        if (i !== workoutIndex) return w;
-        const groupId = w.exercises[exerciseIndex]?.supersetGroupId;
-        if (!groupId) return w;
-        const exercises = w.exercises.map((e) => {
-          if (e.supersetGroupId !== groupId) return e;
-          const { supersetGroupId: _, ...rest } = e;
-          return rest as UserExercise;
-        });
-        return { ...w, exercises };
-      });
-      return { workouts: updatedWorkouts };
-    }),
+          if (oldTrackingType === newTrackingType) {
+            // Same tracking type: carry over old sets
+            newExercise.sets = oldExercise.sets;
+          } else if (newTrackingType === "time") {
+            newExercise.sets = defaultTimeSets;
+          } else if (
+            (newTrackingType === "assisted" && oldTrackingType === "weight") ||
+            (newTrackingType === "weight" && oldTrackingType === "assisted")
+          ) {
+            newExercise.sets = oldExercise.sets;
+          } else {
+            newExercise.sets = defaultSets;
+          }
 
-  // Schedule actions
-  planSchedule: {},
-  setPlanSchedule: (schedule) =>
-    set((state) => {
-      const numWorkouts = state.workouts.length;
-      const validated: Record<number, number> = {};
-      for (const [day, idx] of Object.entries(schedule)) {
-        const dayKey = Number(day);
-        const workoutIdx = Number(idx);
-        if (
-          Number.isInteger(dayKey) &&
-          dayKey >= 0 &&
-          dayKey <= 6 &&
-          Number.isInteger(workoutIdx) &&
-          workoutIdx >= 0 &&
-          workoutIdx < numWorkouts
-        ) {
-          validated[dayKey] = workoutIdx;
-        }
-      }
-      return { planSchedule: validated };
+          const updatedExercises = [...workout.exercises];
+          updatedExercises[exerciseIndex] = newExercise;
+          updatedWorkouts[workoutIndex] = {
+            ...workout,
+            exercises: updatedExercises,
+          };
+
+          return { workouts: updatedWorkouts };
+        });
+      },
+      addSetToExercise: (
+        workoutIndex: number,
+        exerciseId: number,
+        newSet: Set,
+      ) => {
+        set((state) => {
+          const workout = state.workouts[workoutIndex];
+          if (!workout) return state;
+
+          const targetExercise = workout.exercises.find(
+            (e) => e.exercise_id === exerciseId,
+          );
+          const supersetGroupId = targetExercise?.supersetGroupId;
+          const partner = supersetGroupId
+            ? workout.exercises.find(
+                (e) =>
+                  e.exercise_id !== exerciseId &&
+                  e.supersetGroupId === supersetGroupId,
+              )
+            : null;
+
+          const workouts = state.workouts.map((w, wIndex) => {
+            if (wIndex !== workoutIndex) return w;
+            const exercises = w.exercises.map((exercise) => {
+              if (exercise.exercise_id === exerciseId) {
+                return { ...exercise, sets: [...exercise.sets, newSet] };
+              }
+              // Mirror to superset partner: copy partner's last set as template
+              if (partner && exercise.exercise_id === partner.exercise_id) {
+                const lastSet =
+                  exercise.sets[exercise.sets.length - 1] ?? newSet;
+                return {
+                  ...exercise,
+                  sets: [...exercise.sets, { ...lastSet }],
+                };
+              }
+              return exercise;
+            });
+            return { ...w, exercises };
+          });
+          return { workouts };
+        });
+      },
+      updateSetInExercise: (
+        workoutIndex: number,
+        exerciseId: number,
+        setIndex: number,
+        updatedSet: Set,
+      ) => {
+        set((state) => {
+          const workouts = state.workouts.map((workout, wIndex) => {
+            if (wIndex !== workoutIndex) {
+              return workout;
+            }
+            const exercises = workout.exercises.map((exercise) => {
+              if (exercise.exercise_id !== exerciseId) {
+                return exercise;
+              }
+              const sets = exercise.sets.map((set, sIndex) => {
+                if (sIndex !== setIndex) {
+                  return set;
+                }
+                return updatedSet;
+              });
+              return {
+                ...exercise,
+                sets,
+              };
+            });
+            return {
+              ...workout,
+              exercises,
+            };
+          });
+          return { workouts };
+        });
+      },
+      removeSetFromExercise: (
+        workoutIndex: number,
+        exerciseId: number,
+        setIndex: number,
+      ) => {
+        set((state) => {
+          const workout = state.workouts[workoutIndex];
+          if (!workout) return state;
+
+          const targetExercise = workout.exercises.find(
+            (e) => e.exercise_id === exerciseId,
+          );
+          const supersetGroupId = targetExercise?.supersetGroupId;
+          const partner = supersetGroupId
+            ? workout.exercises.find(
+                (e) =>
+                  e.exercise_id !== exerciseId &&
+                  e.supersetGroupId === supersetGroupId,
+              )
+            : null;
+
+          const workouts = state.workouts.map((w, wIndex) => {
+            if (wIndex !== workoutIndex) {
+              return w;
+            }
+            const exercises = w.exercises.map((exercise) => {
+              if (exercise.exercise_id === exerciseId) {
+                // Must keep at least 1 set
+                if (exercise.sets.length <= 1) return exercise;
+                return {
+                  ...exercise,
+                  sets: exercise.sets.filter(
+                    (_, sIndex) => sIndex !== setIndex,
+                  ),
+                };
+              }
+              // Mirror removal to superset partner
+              if (partner && exercise.exercise_id === partner.exercise_id) {
+                if (exercise.sets.length <= 1) return exercise;
+                return {
+                  ...exercise,
+                  sets: exercise.sets.filter(
+                    (_, sIndex) => sIndex !== setIndex,
+                  ),
+                };
+              }
+              return exercise;
+            });
+            return {
+              ...w,
+              exercises,
+            };
+          });
+          return { workouts };
+        });
+      },
+      createSuperset: (workoutIndex, exerciseIndex, newExercise) =>
+        set((state) => {
+          const groupId = Crypto.randomUUID();
+          const updatedWorkouts = state.workouts.map((w, i) => {
+            if (i !== workoutIndex) return w;
+            const exercises = [...w.exercises];
+            exercises[exerciseIndex] = {
+              ...exercises[exerciseIndex],
+              supersetGroupId: groupId,
+            };
+            exercises.splice(exerciseIndex + 1, 0, {
+              ...newExercise,
+              supersetGroupId: groupId,
+            });
+            return { ...w, exercises };
+          });
+          return { workouts: updatedWorkouts };
+        }),
+
+      removeFromSuperset: (workoutIndex, exerciseIndex) =>
+        set((state) => {
+          const updatedWorkouts = state.workouts.map((w, i) => {
+            if (i !== workoutIndex) return w;
+            const groupId = w.exercises[exerciseIndex]?.supersetGroupId;
+            if (!groupId) return w;
+            const exercises = w.exercises.map((e) => {
+              if (e.supersetGroupId !== groupId) return e;
+              const { supersetGroupId: _, ...rest } = e;
+              return rest as UserExercise;
+            });
+            return { ...w, exercises };
+          });
+          return { workouts: updatedWorkouts };
+        }),
+
+      // Schedule actions
+      planSchedule: {},
+      setPlanSchedule: (schedule) =>
+        set((state) => {
+          const numWorkouts = state.workouts.length;
+          const validated: Record<number, number> = {};
+          for (const [day, idx] of Object.entries(schedule)) {
+            const dayKey = Number(day);
+            const workoutIdx = Number(idx);
+            if (
+              Number.isInteger(dayKey) &&
+              dayKey >= 0 &&
+              dayKey <= 6 &&
+              Number.isInteger(workoutIdx) &&
+              workoutIdx >= 0 &&
+              workoutIdx < numWorkouts
+            ) {
+              validated[dayKey] = workoutIdx;
+            }
+          }
+          return { planSchedule: validated };
+        }),
+      clearPlanSchedule: () => set({ planSchedule: {} }),
+      syncScheduleOnRemoveWorkout: (removedIndex) =>
+        set((state) => {
+          const updated: Record<number, number> = {};
+          for (const [day, idx] of Object.entries(state.planSchedule)) {
+            const workoutIdx = Number(idx);
+            if (workoutIdx === removedIndex) continue; // drop this day
+            updated[Number(day)] =
+              workoutIdx > removedIndex ? workoutIdx - 1 : workoutIdx;
+          }
+          return { planSchedule: updated };
+        }),
+
+      draftContext: null,
+      draftId: null,
+      draftName: "",
+      setDraftContext: (context) => set({ draftContext: context }),
+      setDraftId: (id) => set({ draftId: id }),
+      setDraftName: (name) => set({ draftName: name }),
+      clearDraft: () =>
+        set({
+          workouts: [],
+          planImageUrl: DEFAULT_PLAN_IMAGE_URL,
+          planSchedule: {},
+          draftContext: null,
+          draftId: null,
+          draftName: "",
+        }),
     }),
-  clearPlanSchedule: () => set({ planSchedule: {} }),
-  syncScheduleOnRemoveWorkout: (removedIndex) =>
-    set((state) => {
-      const updated: Record<number, number> = {};
-      for (const [day, idx] of Object.entries(state.planSchedule)) {
-        const workoutIdx = Number(idx);
-        if (workoutIdx === removedIndex) continue; // drop this day
-        updated[Number(day)] =
-          workoutIdx > removedIndex ? workoutIdx - 1 : workoutIdx;
-      }
-      return { planSchedule: updated };
-    }),
-}));
+    {
+      name: "workout-draft-store",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({
+        workouts: state.workouts,
+        planImageUrl: state.planImageUrl,
+        planSchedule: state.planSchedule,
+        draftContext: state.draftContext,
+        draftId: state.draftId,
+        draftName: state.draftName,
+      }),
+    },
+  ),
+);
 
 export { useWorkoutStore };

--- a/store/workoutStore.ts
+++ b/store/workoutStore.ts
@@ -325,8 +325,14 @@ const useWorkoutStore = create<WorkoutStore>()(
               if (partner && exercise.exercise_id === partner.exercise_id) {
                 const lastSet =
                   exercise.sets[exercise.sets.length - 1] ?? newSet;
+                const clone = {
+                  ...lastSet,
+                  isWarmup: newSet.isWarmup,
+                  isDropSet: newSet.isDropSet,
+                  isToFailure: newSet.isToFailure,
+                };
                 const sets = [...exercise.sets];
-                sets.splice(atIndex, 0, { ...lastSet });
+                sets.splice(atIndex, 0, clone);
                 return { ...exercise, sets };
               }
               return exercise;

--- a/utils/__tests__/loadPremadePlans.test.ts
+++ b/utils/__tests__/loadPremadePlans.test.ts
@@ -13,6 +13,58 @@ jest.mock(
   () => [{ app_plan_id: 2, name: "4 Day Split", workouts: [] }],
   { virtual: true },
 );
+// 5-day-bro-split has one exercise so we can test ID translation + ensureAppExercisesExist
+jest.mock(
+  "@/assets/data/5-day-bro-split.json",
+  () => [
+    {
+      app_plan_id: 3,
+      name: "5 Day Bro Split",
+      workouts: [
+        {
+          id: null,
+          plan_id: null,
+          name: "Day 1 – Chest",
+          is_deleted: false,
+          exercises: [
+            {
+              id: null,
+              workout_id: null,
+              exercise_id: 11,
+              exercise_name: "Barbell Bench Press",
+              sets: [
+                { repsMin: 8, repsMax: 10, restMinutes: 2, restSeconds: 0 },
+              ],
+              exercise_order: 1,
+              is_deleted: false,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  { virtual: true },
+);
+jest.mock(
+  "@/assets/data/5-day-ppl.json",
+  () => [{ app_plan_id: 7, name: "5 Day PPL", workouts: [] }],
+  { virtual: true },
+);
+jest.mock(
+  "@/assets/data/6-day-split.json",
+  () => [{ app_plan_id: 4, name: "6 Day Split", workouts: [] }],
+  { virtual: true },
+);
+jest.mock(
+  "@/assets/data/body-weight.json",
+  () => [{ app_plan_id: 5, name: "Bodyweight (3 Days)", workouts: [] }],
+  { virtual: true },
+);
+jest.mock(
+  "@/assets/data/dumbbell-only.json",
+  () => [{ app_plan_id: 6, name: "Dumbbell Only (4 Days)", workouts: [] }],
+  { virtual: true },
+);
 jest.mock("@bugsnag/expo");
 
 const mockRunAsync = jest.fn();
@@ -20,24 +72,32 @@ const mockGetFirstAsync = jest.fn();
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockRunAsync.mockResolvedValue({ lastInsertRowId: 1 });
   (openDatabase as jest.Mock).mockResolvedValue({
     runAsync: mockRunAsync,
     getFirstAsync: mockGetFirstAsync,
     withExclusiveTransactionAsync: jest.fn((fn) =>
-      fn({ runAsync: mockRunAsync }),
+      fn({ runAsync: mockRunAsync, getFirstAsync: mockGetFirstAsync }),
     ),
   });
 });
 
-it("should insert plans and update data version if dataVersion is null", async () => {
-  mockGetFirstAsync.mockResolvedValue(null); // No dataVersion exists
-  mockRunAsync.mockResolvedValue({}); // Mock database writes
+it("should insert v1.8 and v2.1 plans and update both data versions if dataVersion is null", async () => {
+  mockGetFirstAsync.mockImplementation((sql: string) => {
+    if (sql.includes("app_exercise_id = ?"))
+      return Promise.resolve({ exercise_id: 42 });
+    return Promise.resolve(null);
+  });
 
   await loadPremadePlans();
 
   expect(mockRunAsync).toHaveBeenCalledWith(
     "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
     ["dataVersion", "1.8"],
+  );
+  expect(mockRunAsync).toHaveBeenCalledWith(
+    "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+    ["dataVersion", "2.1"],
   );
   expect(mockRunAsync).toHaveBeenCalledWith(
     expect.stringContaining("INSERT INTO user_plans"),
@@ -46,21 +106,44 @@ it("should insert plans and update data version if dataVersion is null", async (
 });
 
 it("should handle database errors when inserting plans", async () => {
-  mockGetFirstAsync.mockResolvedValue(null); // No dataVersion exists
+  mockGetFirstAsync.mockResolvedValue(null);
   const dbError = new Error("Database insertion failed");
-  mockRunAsync.mockRejectedValue(dbError); // Simulate database error
+  mockRunAsync.mockRejectedValue(dbError);
 
   await expect(loadPremadePlans()).rejects.toThrow("Database insertion failed");
 
-  // Verify attempt was made to insert plans
   expect(mockRunAsync).toHaveBeenCalledWith(
     expect.stringContaining("INSERT INTO user_plans"),
     expect.any(Array),
   );
 });
 
-it("should skip inserting plans if dataVersion is 1.8 or higher", async () => {
-  mockGetFirstAsync.mockResolvedValue({ value: "1.8" }); // Already up-to-date
+it("should skip v1.8 plans but load v2.1 plans when dataVersion is 1.8", async () => {
+  mockGetFirstAsync.mockImplementation((sql: string) => {
+    if (sql.includes("key = ?")) return Promise.resolve({ value: "1.8" });
+    if (sql.includes("app_exercise_id = ?"))
+      return Promise.resolve({ exercise_id: 42 });
+    return Promise.resolve(null);
+  });
+
+  await loadPremadePlans();
+
+  expect(mockRunAsync).not.toHaveBeenCalledWith(
+    "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+    ["dataVersion", "1.8"],
+  );
+  expect(mockRunAsync).toHaveBeenCalledWith(
+    "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+    ["dataVersion", "2.1"],
+  );
+  expect(mockRunAsync).toHaveBeenCalledWith(
+    expect.stringContaining("INSERT INTO user_plans"),
+    expect.any(Array),
+  );
+});
+
+it("should skip all plan insertions if dataVersion is 2.1 or higher", async () => {
+  mockGetFirstAsync.mockResolvedValue({ value: "2.1" });
 
   await loadPremadePlans();
 
@@ -70,7 +153,7 @@ it("should skip inserting plans if dataVersion is 1.8 or higher", async () => {
   );
   expect(mockRunAsync).not.toHaveBeenCalledWith(
     "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
-    ["dataVersion", "1.8"],
+    expect.any(Array),
   );
 });
 
@@ -80,4 +163,76 @@ it("should handle database errors and notify Bugsnag", async () => {
   await expect(loadPremadePlans()).rejects.toThrow("Database error");
 
   expect(Bugsnag.notify).toHaveBeenCalledWith(expect.any(Error));
+});
+
+it("should translate app exercise IDs to local userData IDs when inserting exercises", async () => {
+  const localExerciseId = 42;
+  mockGetFirstAsync.mockImplementation((sql: string) => {
+    if (sql.includes("key = ?")) return Promise.resolve({ value: "1.8" });
+    if (sql.includes("app_exercise_id = ?"))
+      return Promise.resolve({ exercise_id: localExerciseId });
+    return Promise.resolve(null);
+  });
+
+  await loadPremadePlans();
+
+  expect(mockRunAsync).toHaveBeenCalledWith(
+    expect.stringContaining("INSERT INTO user_workout_exercises"),
+    expect.arrayContaining([localExerciseId]),
+  );
+});
+
+it("should throw and roll back when an exercise's app_exercise_id is not found in userData", async () => {
+  mockGetFirstAsync.mockImplementation((sql: string) => {
+    if (sql.includes("key = ?")) return Promise.resolve({ value: "1.8" });
+    return Promise.resolve(null); // exercise not found anywhere
+  });
+
+  await expect(loadPremadePlans()).rejects.toThrow(
+    /Exercise with app_exercise_id=11 not found in userData\.db/,
+  );
+
+  expect(mockRunAsync).not.toHaveBeenCalledWith(
+    expect.stringContaining("INSERT INTO user_workout_exercises"),
+    expect.any(Array),
+  );
+});
+
+it("should copy missing exercises from appData3.db into userData.db", async () => {
+  const appExerciseRow = {
+    exercise_id: 11,
+    name: "Barbell Bench Press",
+    image: null,
+    local_animated_uri: null,
+    animated_url: null,
+    equipment: "barbell",
+    body_part: "chest",
+    target_muscle: "pectoralis major sternal head",
+    secondary_muscles: null,
+    description: null,
+    is_deleted: 0,
+    tracking_type: null,
+    is_unilateral: null,
+    double_weight: null,
+  };
+  let exerciseCopied = false;
+  mockRunAsync.mockImplementation((sql: string) => {
+    if (sql.includes("INSERT INTO exercises")) exerciseCopied = true;
+    return Promise.resolve({ lastInsertRowId: 1 });
+  });
+  mockGetFirstAsync.mockImplementation((sql: string) => {
+    if (sql.includes("key = ?")) return Promise.resolve({ value: "1.8" });
+    if (sql.includes("app_exercise_id = ?"))
+      return Promise.resolve(exerciseCopied ? { exercise_id: 11 } : null);
+    if (sql.includes("WHERE exercise_id = ?"))
+      return Promise.resolve(appExerciseRow); // found in appData3
+    return Promise.resolve(null);
+  });
+
+  await loadPremadePlans();
+
+  expect(mockRunAsync).toHaveBeenCalledWith(
+    expect.stringContaining("INSERT INTO exercises"),
+    expect.arrayContaining([11, "Barbell Bench Press"]),
+  );
 });

--- a/utils/estimateWorkoutDuration.ts
+++ b/utils/estimateWorkoutDuration.ts
@@ -115,6 +115,7 @@ function estimateSetWorkDuration(
 export function computeWorkoutDurationEstimate(
   exercises: UserExercise[],
   historyByExerciseId: Record<number, number[]>,
+  countUnilateralDouble = false,
 ): DurationEstimate {
   // In a superset the transition from exercise A to B has no rest — only B's
   // rest counts (the between-round recovery). Collect the exercise_id of the
@@ -145,8 +146,10 @@ export function computeWorkoutDurationEstimate(
         exercise.equipment,
         history,
       );
-      totalMin += workMin + rest;
-      totalMax += workMax + rest;
+      const unilateralMul =
+        countUnilateralDouble && exercise.is_unilateral ? 2 : 1;
+      totalMin += workMin * unilateralMul + rest;
+      totalMax += workMax * unilateralMul + rest;
     }
   }
 
@@ -170,4 +173,21 @@ export function formatDurationEstimate(estimate: DurationEstimate): string {
     return `~${minStr}`;
   }
   return `${minStr} – ${maxStr}`;
+}
+
+function formatMinutesCompact(totalSeconds: number): string {
+  const totalMins = Math.ceil(totalSeconds / 60);
+  if (totalMins < 60) return `${totalMins}m`;
+  const hours = Math.floor(totalMins / 60);
+  const mins = totalMins % 60;
+  return mins === 0 ? `${hours}h` : `${hours}h${String(mins).padStart(2, "0")}`;
+}
+
+export function formatDurationEstimateCompact(
+  estimate: DurationEstimate,
+): string {
+  const minStr = formatMinutesCompact(estimate.minSeconds);
+  const maxStr = formatMinutesCompact(estimate.maxSeconds);
+  if (minStr === maxStr) return minStr;
+  return `${minStr}–${maxStr}`;
 }

--- a/utils/estimateWorkoutDuration.ts
+++ b/utils/estimateWorkoutDuration.ts
@@ -170,7 +170,7 @@ export function formatDurationEstimate(estimate: DurationEstimate): string {
   const minStr = formatMinutes(estimate.minSeconds);
   const maxStr = formatMinutes(estimate.maxSeconds);
   if (minStr === maxStr) {
-    return `~${minStr}`;
+    return `${minStr}`;
   }
   return `${minStr} – ${maxStr}`;
 }

--- a/utils/loadPremadePlans.ts
+++ b/utils/loadPremadePlans.ts
@@ -108,10 +108,9 @@ const insertPlans = async (db: SQLiteDatabase, plans: Plan[]) => {
               [exercise.exercise_id],
             );
             if (!localExercise) {
-              console.warn(
-                `Exercise with app_exercise_id=${exercise.exercise_id} not found in userData.db, skipping.`,
+              throw new Error(
+                `Exercise with app_exercise_id=${exercise.exercise_id} not found in userData.db (plan app_plan_id=${plan.app_plan_id})`,
               );
-              continue;
             }
 
             const setsJson = JSON.stringify(exercise.sets); // Convert sets array to JSON string

--- a/utils/loadPremadePlans.ts
+++ b/utils/loadPremadePlans.ts
@@ -3,6 +3,52 @@ import { openDatabase } from "./database";
 import { SQLiteDatabase } from "expo-sqlite";
 import Bugsnag from "@bugsnag/expo";
 
+const ensureAppExercisesExist = async (
+  userDb: SQLiteDatabase,
+  appExerciseIds: number[],
+): Promise<void> => {
+  const appDb = await openDatabase("appData3.db");
+  for (const appId of appExerciseIds) {
+    const exists = await userDb.getFirstAsync(
+      "SELECT exercise_id FROM exercises WHERE app_exercise_id = ? LIMIT 1",
+      [appId],
+    );
+    if (!exists) {
+      const row = await appDb.getFirstAsync<Record<string, any>>(
+        "SELECT * FROM exercises WHERE exercise_id = ? LIMIT 1",
+        [appId],
+      );
+      if (row) {
+        await userDb.runAsync(
+          `INSERT INTO exercises (app_exercise_id, name, image, local_animated_uri, animated_url, equipment, body_part, target_muscle, secondary_muscles, description, is_deleted, tracking_type, is_unilateral, double_weight)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            row.exercise_id,
+            row.name,
+            row.image ?? null,
+            row.local_animated_uri ?? null,
+            row.animated_url ?? null,
+            row.equipment ?? null,
+            row.body_part ?? null,
+            row.target_muscle ?? null,
+            row.secondary_muscles ?? null,
+            row.description ?? null,
+            row.is_deleted ?? 0,
+            row.tracking_type ?? null,
+            row.is_unilateral ?? null,
+            row.double_weight ?? null,
+          ],
+        );
+        console.log(`Copied exercise app_exercise_id=${appId} to userData.db`);
+      } else {
+        console.warn(
+          `Exercise with app_exercise_id=${appId} not found in appData3.db`,
+        );
+      }
+    }
+  }
+};
+
 const insertPlans = async (db: SQLiteDatabase, plans: Plan[]) => {
   const plansToInsert: Plan[] = [];
 
@@ -54,13 +100,27 @@ const insertPlans = async (db: SQLiteDatabase, plans: Plan[]) => {
 
           // Step 4: Insert each exercise within this workout into user_workout_exercises
           for (const exercise of workout.exercises) {
+            // Translate appData exercise_id to local userData exercise_id
+            const localExercise = await txn.getFirstAsync<{
+              exercise_id: number;
+            }>(
+              "SELECT exercise_id FROM exercises WHERE app_exercise_id = ? LIMIT 1",
+              [exercise.exercise_id],
+            );
+            if (!localExercise) {
+              console.warn(
+                `Exercise with app_exercise_id=${exercise.exercise_id} not found in userData.db, skipping.`,
+              );
+              continue;
+            }
+
             const setsJson = JSON.stringify(exercise.sets); // Convert sets array to JSON string
 
             await txn.runAsync(
               "INSERT INTO user_workout_exercises (workout_id, exercise_id, sets, exercise_order, is_deleted) VALUES (?, ?, ?, ?, ?)",
               [
                 workoutId,
-                exercise.exercise_id,
+                localExercise.exercise_id,
                 setsJson,
                 exercise.exercise_order ?? null,
                 exercise.is_deleted ?? false,
@@ -100,6 +160,47 @@ export const loadPremadePlans = async () => {
       await db.runAsync(
         "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
         ["dataVersion", "1.8"],
+      );
+      dataVersion = 1.8;
+    }
+
+    if ((dataVersion ?? 0) < 2.1) {
+      console.log("Loading new premade plans (v2.1)...");
+      const newPlanFiles = [
+        require("@/assets/data/5-day-bro-split.json"),
+        require("@/assets/data/5-day-ppl.json"),
+        require("@/assets/data/6-day-split.json"),
+        require("@/assets/data/body-weight.json"),
+        require("@/assets/data/dumbbell-only.json"),
+      ];
+
+      // Collect all unique appData exercise IDs referenced in these plans
+      const allAppExerciseIds = new Set<number>();
+      for (const file of newPlanFiles) {
+        const plansArray: Plan[] = Array.isArray(file) ? file : [file];
+        for (const plan of plansArray) {
+          for (const workout of plan.workouts) {
+            for (const exercise of workout.exercises) {
+              if (exercise.exercise_id != null) {
+                allAppExerciseIds.add(exercise.exercise_id);
+              }
+            }
+          }
+        }
+      }
+
+      // Ensure all referenced exercises exist in userData.db
+      await ensureAppExercisesExist(db, Array.from(allAppExerciseIds));
+
+      for (const file of newPlanFiles) {
+        const plansArray = Array.isArray(file) ? file : [file];
+        await insertPlans(db, plansArray);
+      }
+
+      console.log("Updating data version to 2.1...");
+      await db.runAsync(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+        ["dataVersion", "2.1"],
       );
     }
   } catch (error: any) {


### PR DESCRIPTION
## Summary by Sourcery

Persist workout and plan editing drafts across sessions, enhance workout duration insights and stats display, and improve set and warm-up management in workouts.

New Features:
- Persist workout and plan builder state to AsyncStorage to support resuming drafts for plans and standalone workouts.
- Prompt users to continue or discard existing drafts when reopening plan or standalone workout editors.
- Estimate and display workout duration alongside exercise counts in plan overviews, home screen workouts, and standalone workout lists.
- Add warm-up set management with grouping, visual separation, and targeted bulk editing for warm-up versus working sets.
- Provide quick access to exercise details from the sets overview header and improve layout of stats insights and tiles.

Bug Fixes:
- Fix weekly streak and stats insights to use all completed workouts and correctly compute weekly goal progress.

Enhancements:
- Refine workout set manipulation APIs in the store, including inserting sets at specific positions and keeping superset partners in sync.
- Improve navigation discard flows to clear drafts appropriately when leaving plan or workout editors.
- Update stats insights strip to support a responsive grid layout for larger numbers of insights and make stat tiles flex to available width.
- Adjust workout duration estimation to optionally count unilateral exercises as double based on user settings and add compact formatting helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save and resume draft workouts and plans with an on-screen prompt to continue or discard
  * Per-workout duration estimates shown on workout cards and lists (respecting user settings)
  * Add warm-up sets via a dedicated "Add Warm-up" button
  * Weekly streak and weekly goal progress shown in Statistics

* **Improvements**
  * Drafts cleared on navigation and after successful save; UI waits for draft resolution before loading
  * Warm-up sets grouped and styled; "Apply to all" targets warmup or working sets with dynamic label
  * Insights adapt to a two-column grid when many items exist

* **UX**
  * More compact duration formatting for display

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/isotronic/MuscleQuest/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->