### PR TITLE
feat: add calendar modal for workout history

### DIFF
--- a/app/(app)/(tabs)/(stats)/index.tsx
+++ b/app/(app)/(tabs)/(stats)/index.tsx
@@ -1,6 +1,11 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
-import { ActivityIndicator, Button, Divider } from "react-native-paper";
+import {
+  ActivityIndicator,
+  Button,
+  Divider,
+  IconButton,
+} from "react-native-paper";
 import { TimeRangeSelector } from "@/components/stats/TimeRangeSelector";
 import { ThemedView } from "@/components/ThemedView";
 import { ThemedText } from "@/components/ThemedText";
@@ -9,11 +14,12 @@ import {
   useCompletedWorkoutsQuery,
   usePreviousPeriodWorkoutsQuery,
 } from "@/hooks/useCompletedWorkoutsQuery";
-import { startOfWeek, endOfWeek } from "date-fns";
+import { startOfWeek, endOfWeek, format } from "date-fns";
 import { useWeeklyStreak } from "@/hooks/useWeeklyStreak";
 import { useExercisesQuery } from "@/hooks/useExercisesQuery";
 import { Colors } from "@/constants/Colors";
 import { WorkoutHistorySection } from "@/components/stats/WorkoutHistorySection";
+import { WorkoutCalendarModal } from "@/components/stats/WorkoutCalendarModal";
 import { InsightsStrip } from "@/components/stats/InsightsStrip";
 import { StatsTile } from "@/components/stats/StatsTile";
 import { ExerciseCompactCard } from "@/components/stats/ExerciseCompactCard";
@@ -90,6 +96,8 @@ export default function StatsScreen() {
   const [selectedTimeRange, setSelectedTimeRange] = useState<string>(
     settings?.timeRange || "30",
   );
+  const [historyVisible, setHistoryVisible] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
 
   useEffect(() => {
     if (settings?.timeRange) setSelectedTimeRange(settings.timeRange);
@@ -189,6 +197,37 @@ export default function StatsScreen() {
     (id: number) => router.push(`/history-details?id=${id}`),
     [router],
   );
+
+  const workoutsByDate = useMemo(() => {
+    const map: Record<string, CompletedWorkout[]> = {};
+    for (const w of completedWorkouts ?? []) {
+      const key = format(new Date(w.date_completed), "yyyy-MM-dd");
+      (map[key] ??= []).push(w);
+    }
+    return map;
+  }, [completedWorkouts]);
+
+  const markedDates = useMemo(() => {
+    const marks: Record<string, object> = {};
+    for (const date of Object.keys(workoutsByDate)) {
+      marks[date] = { marked: true, dotColor: Colors.dark.tint };
+    }
+    if (selectedDate) {
+      marks[selectedDate] = {
+        ...(marks[selectedDate] ?? {}),
+        selected: true,
+        selectedColor: Colors.dark.tint,
+      };
+    }
+    return marks;
+  }, [workoutsByDate, selectedDate]);
+
+  const handleOpenCalendar = useCallback(() => {
+    const today = format(new Date(), "yyyy-MM-dd");
+    const fallback = Object.keys(workoutsByDate).sort().reverse()[0] ?? null;
+    setSelectedDate(workoutsByDate[today] ? today : fallback);
+    setHistoryVisible(true);
+  }, [workoutsByDate]);
 
   const handleExercisePress = useCallback(
     (exerciseId: number, name: string) =>
@@ -333,7 +372,18 @@ export default function StatsScreen() {
 
         {/* Workout history */}
         <View style={styles.section}>
-          <ThemedText style={styles.sectionTitle}>Workout History</ThemedText>
+          <View style={styles.sectionHeader}>
+            <ThemedText style={styles.sectionTitle}>Workout History</ThemedText>
+            {(completedWorkouts?.length ?? 0) > 0 && (
+              <IconButton
+                icon="calendar-month"
+                size={20}
+                iconColor={Colors.dark.tint}
+                style={{ margin: 0 }}
+                onPress={handleOpenCalendar}
+              />
+            )}
+          </View>
           <WorkoutHistorySection
             completedWorkouts={completedWorkouts ?? []}
             onWorkoutPress={handleWorkoutPress}
@@ -419,6 +469,21 @@ export default function StatsScreen() {
           )}
         </View>
       </ScrollView>
+      <WorkoutCalendarModal
+        visible={historyVisible}
+        onDismiss={() => setHistoryVisible(false)}
+        markedDates={markedDates}
+        selectedDate={selectedDate}
+        onDayPress={(dateString) => setSelectedDate(dateString)}
+        workoutsForSelectedDate={
+          selectedDate ? (workoutsByDate[selectedDate] ?? []) : []
+        }
+        onWorkoutPress={(id) => {
+          setHistoryVisible(false);
+          handleWorkoutPress(id);
+        }}
+        excludeWarmup={excludeWarmup}
+      />
     </ThemedView>
   );
 }

--- a/app/(app)/(tabs)/(stats)/index.tsx
+++ b/app/(app)/(tabs)/(stats)/index.tsx
@@ -208,15 +208,49 @@ export default function StatsScreen() {
   }, [completedWorkouts]);
 
   const markedDates = useMemo(() => {
+    const today = format(new Date(), "yyyy-MM-dd");
     const marks: Record<string, object> = {};
     for (const date of Object.keys(workoutsByDate)) {
-      marks[date] = { marked: true, dotColor: Colors.dark.tint };
+      marks[date] = {
+        customStyles: {
+          container: {
+            borderWidth: 1.5,
+            borderColor: Colors.dark.tint,
+            borderRadius: 16,
+          },
+          text: {
+            color: date === today ? Colors.dark.tint : Colors.dark.text,
+            fontWeight:
+              date === today ? ("bold" as const) : ("normal" as const),
+          },
+        },
+      };
+    }
+    // Ensure today is always bold even when it has no workout
+    if (!marks[today]) {
+      marks[today] = {
+        customStyles: {
+          container: {},
+          text: {
+            color: Colors.dark.tint,
+            fontWeight: "bold" as const,
+          },
+        },
+      };
     }
     if (selectedDate) {
       marks[selectedDate] = {
-        ...(marks[selectedDate] ?? {}),
-        selected: true,
-        selectedColor: Colors.dark.tint,
+        customStyles: {
+          container: {
+            backgroundColor: Colors.dark.tint,
+            borderRadius: 16,
+          },
+          text: {
+            color: Colors.dark.background,
+            fontWeight:
+              selectedDate === today ? ("bold" as const) : ("normal" as const),
+          },
+        },
       };
     }
     return marks;
@@ -483,6 +517,7 @@ export default function StatsScreen() {
           handleWorkoutPress(id);
         }}
         excludeWarmup={excludeWarmup}
+        loading={isLoadingWorkouts}
       />
     </ThemedView>
   );

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -299,6 +299,7 @@ export default function HomeScreen() {
             visible={pickerWorkouts.length > 0}
             onDismiss={() => setPickerWorkouts([])}
             contentContainerStyle={styles.pickerModal}
+            theme={{ colors: { backdrop: "rgba(0, 0, 0, 0.65)" } }}
           >
             <ThemedText type="subtitle" style={styles.pickerTitle}>
               Select a workout to view

--- a/app/(app)/(workout)/index.tsx
+++ b/app/(app)/(workout)/index.tsx
@@ -781,6 +781,7 @@ export default function WorkoutOverviewScreen() {
           visible={showSaveModal}
           onDismiss={handleExitSaveModal}
           contentContainerStyle={styles.saveModal}
+          theme={{ colors: { backdrop: "rgba(0, 0, 0, 0.65)" } }}
         >
           <ThemedText style={styles.saveModalTitle}>
             Save this workout?

--- a/components/EditSetModal.tsx
+++ b/components/EditSetModal.tsx
@@ -453,7 +453,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    backgroundColor: "rgba(0,0,0,0.5)",
+    backgroundColor: "rgba(0,0,0,0.65)",
   },
   modalContent: {
     backgroundColor: Colors.dark.cardBackground,

--- a/components/PlanScheduleEditor.tsx
+++ b/components/PlanScheduleEditor.tsx
@@ -115,6 +115,7 @@ export default function PlanScheduleEditor({
           visible={pickerDow !== null}
           onDismiss={() => setPickerDow(null)}
           contentContainerStyle={styles.modalContent}
+          theme={{ colors: { backdrop: "rgba(0, 0, 0, 0.65)" } }}
         >
           <View style={styles.modalTitleContainer}>
             <ThemedText style={styles.modalTitle}>

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -335,7 +335,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    backgroundColor: "rgba(0,0,0,0.5)",
+    backgroundColor: "rgba(0,0,0,0.65)",
   },
   modalContent: {
     backgroundColor: Colors.dark.cardBackground,

--- a/components/UpdateModal.tsx
+++ b/components/UpdateModal.tsx
@@ -53,6 +53,7 @@ export const UpdateModal = () => {
         visible={true}
         dismissable={status === "error"}
         onDismiss={status === "error" ? dismissError : undefined}
+        theme={{ colors: { backdrop: "rgba(0, 0, 0, 0.65)" } }}
       >
         <View style={styles.container}>
           <ThemedText type="subtitle">{content.title}</ThemedText>

--- a/components/WhatsNewModal.tsx
+++ b/components/WhatsNewModal.tsx
@@ -59,7 +59,11 @@ export const WhatsNewModal = () => {
 
   return (
     <Portal>
-      <Modal visible={visible} onDismiss={handleNext}>
+      <Modal
+        visible={visible}
+        onDismiss={handleNext}
+        theme={{ colors: { backdrop: "rgba(0, 0, 0, 0.65)" } }}
+      >
         <View
           style={{
             backgroundColor: Colors.dark.cardBackground2,

--- a/components/WorkoutHistoryCard.tsx
+++ b/components/WorkoutHistoryCard.tsx
@@ -1,7 +1,5 @@
-import type { ComponentProps } from "react";
-import { StyleSheet, TouchableOpacity, View } from "react-native";
-import { ThemedView } from "@/components/ThemedView";
-import { ThemedText } from "@/components/ThemedText";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { format } from "date-fns";
 import { CompletedWorkout } from "@/hooks/useCompletedWorkoutsQuery";
 import { Colors } from "@/constants/Colors";
 
@@ -9,16 +7,14 @@ interface WorkoutCardProps {
   workout: CompletedWorkout;
   onPress: (id: number) => void;
   excludeWarmup?: boolean;
-  containerStyle?: ComponentProps<typeof TouchableOpacity>["style"];
-  cardStyle?: ComponentProps<typeof View>["style"];
+  variant?: "horizontal" | "vertical";
 }
 
 export default function WorkoutHistoryCard({
   workout,
   onPress,
   excludeWarmup = false,
-  containerStyle,
-  cardStyle,
+  variant = "horizontal",
 }: WorkoutCardProps) {
   const setsCount = excludeWarmup
     ? workout.exercises.reduce(
@@ -26,56 +22,110 @@ export default function WorkoutHistoryCard({
         0,
       )
     : workout.total_sets_completed;
+
+  const durationMin = Math.round(workout.duration / 60);
+  const dateLabel = format(new Date(workout.date_completed), "EEE, d MMM");
+  const isVertical = variant === "vertical";
+
   return (
     <TouchableOpacity
       onPress={() => onPress(workout.id)}
-      style={[styles.cardContainer, containerStyle]}
+      style={[
+        styles.container,
+        isVertical ? styles.containerVertical : styles.containerHorizontal,
+      ]}
+      activeOpacity={0.7}
     >
-      <ThemedView style={[styles.card, cardStyle]}>
-        <ThemedText style={styles.workoutName}>
-          {workout.workout_name}
-        </ThemedText>
-        <ThemedText style={styles.workoutDate}>
-          {new Date(workout.date_completed).toLocaleDateString()}
-        </ThemedText>
-        <ThemedText style={styles.workoutDuration}>
-          Duration: {Math.round(workout.duration / 60)} min
-        </ThemedText>
-        <ThemedText style={styles.workoutSets}>Sets: {setsCount}</ThemedText>
-      </ThemedView>
+      <View
+        style={[
+          styles.card,
+          isVertical ? styles.cardVertical : styles.cardHorizontal,
+        ]}
+      >
+        <View style={styles.row}>
+          <Text style={styles.name} numberOfLines={1}>
+            {workout.workout_name}
+          </Text>
+          {isVertical && <Text style={styles.chevron}>›</Text>}
+        </View>
+        <Text style={styles.date}>{dateLabel}</Text>
+        <View style={styles.chips}>
+          <View style={styles.chip}>
+            <Text style={styles.chipText}>{durationMin} min</Text>
+          </View>
+          <View style={styles.chip}>
+            <Text style={styles.chipText}>{setsCount} sets</Text>
+          </View>
+        </View>
+      </View>
     </TouchableOpacity>
   );
 }
 
 const styles = StyleSheet.create({
-  cardContainer: {
+  container: {
+    borderRadius: 8,
+    overflow: "hidden",
+  },
+  containerHorizontal: {
+    width: 180,
     marginRight: 8,
   },
+  containerVertical: {
+    width: "100%",
+    marginBottom: 8,
+  },
   card: {
-    width: 200,
-    padding: 16,
-    borderRadius: 6,
-    backgroundColor: Colors.dark.cardBackground,
+    padding: 14,
+    borderRadius: 8,
+    borderLeftWidth: 3,
+    borderLeftColor: Colors.dark.tint,
     shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.2,
-    shadowRadius: 4,
-    elevation: 4, // For Android shadow
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.15,
+    shadowRadius: 3,
+    elevation: 3,
   },
-  workoutName: {
-    fontSize: 16,
+  cardHorizontal: {
+    backgroundColor: Colors.dark.cardBackground,
+  },
+  cardVertical: {
+    backgroundColor: Colors.dark.cardBackground2,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  name: {
+    flex: 1,
+    fontSize: 15,
     fontWeight: "bold",
+    color: Colors.dark.text,
   },
-  workoutDate: {
-    marginTop: 8,
-    fontSize: 14,
+  chevron: {
+    fontSize: 20,
+    color: Colors.dark.subText,
+    marginLeft: 4,
   },
-  workoutDuration: {
+  date: {
     marginTop: 4,
-    fontSize: 14,
+    fontSize: 12,
+    color: Colors.dark.subText,
   },
-  workoutSets: {
-    marginTop: 4,
-    fontSize: 14,
+  chips: {
+    flexDirection: "row",
+    gap: 6,
+    marginTop: 10,
+  },
+  chip: {
+    backgroundColor: "rgba(255, 255, 255, 0.12)",
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  chipText: {
+    fontSize: 12,
+    color: Colors.dark.text,
   },
 });

--- a/components/WorkoutHistoryCard.tsx
+++ b/components/WorkoutHistoryCard.tsx
@@ -1,4 +1,5 @@
-import { StyleSheet, TouchableOpacity } from "react-native";
+import type { ComponentProps } from "react";
+import { StyleSheet, TouchableOpacity, View } from "react-native";
 import { ThemedView } from "@/components/ThemedView";
 import { ThemedText } from "@/components/ThemedText";
 import { CompletedWorkout } from "@/hooks/useCompletedWorkoutsQuery";
@@ -8,12 +9,16 @@ interface WorkoutCardProps {
   workout: CompletedWorkout;
   onPress: (id: number) => void;
   excludeWarmup?: boolean;
+  containerStyle?: ComponentProps<typeof TouchableOpacity>["style"];
+  cardStyle?: ComponentProps<typeof View>["style"];
 }
 
 export default function WorkoutHistoryCard({
   workout,
   onPress,
   excludeWarmup = false,
+  containerStyle,
+  cardStyle,
 }: WorkoutCardProps) {
   const setsCount = excludeWarmup
     ? workout.exercises.reduce(
@@ -24,9 +29,9 @@ export default function WorkoutHistoryCard({
   return (
     <TouchableOpacity
       onPress={() => onPress(workout.id)}
-      style={styles.cardContainer}
+      style={[styles.cardContainer, containerStyle]}
     >
-      <ThemedView style={styles.card}>
+      <ThemedView style={[styles.card, cardStyle]}>
         <ThemedText style={styles.workoutName}>
           {workout.workout_name}
         </ThemedText>

--- a/components/stats/WorkoutCalendarModal.tsx
+++ b/components/stats/WorkoutCalendarModal.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { ScrollView, StyleSheet, View } from "react-native";
+import { Modal, Portal, Divider, IconButton } from "react-native-paper";
+import { Calendar, DateData } from "react-native-calendars";
+import { format, parseISO } from "date-fns";
+import { ThemedText } from "@/components/ThemedText";
+import WorkoutHistoryCard from "@/components/WorkoutHistoryCard";
+import { CompletedWorkout } from "@/hooks/useCompletedWorkoutsQuery";
+import { Colors } from "@/constants/Colors";
+
+interface WorkoutCalendarModalProps {
+  visible: boolean;
+  onDismiss: () => void;
+  markedDates: Record<string, object>;
+  selectedDate: string | null;
+  onDayPress: (dateString: string) => void;
+  workoutsForSelectedDate: CompletedWorkout[];
+  onWorkoutPress: (id: number) => void;
+  excludeWarmup?: boolean;
+}
+
+const calendarTheme = {
+  backgroundColor: Colors.dark.cardBackground,
+  calendarBackground: Colors.dark.cardBackground,
+  dayTextColor: Colors.dark.text,
+  todayTextColor: Colors.dark.tint,
+  selectedDayBackgroundColor: Colors.dark.tint,
+  selectedDayTextColor: Colors.dark.background,
+  dotColor: Colors.dark.tint,
+  selectedDotColor: Colors.dark.background,
+  monthTextColor: Colors.dark.text,
+  arrowColor: Colors.dark.tint,
+  textDisabledColor: Colors.dark.subText,
+  textSectionTitleColor: Colors.dark.subText,
+};
+
+export const WorkoutCalendarModal: React.FC<WorkoutCalendarModalProps> = ({
+  visible,
+  onDismiss,
+  markedDates,
+  selectedDate,
+  onDayPress,
+  workoutsForSelectedDate,
+  onWorkoutPress,
+  excludeWarmup = false,
+}) => {
+  const formattedHeading = selectedDate
+    ? format(parseISO(selectedDate), "EEEE, d MMMM")
+    : null;
+
+  return (
+    <Portal>
+      <Modal
+        visible={visible}
+        onDismiss={onDismiss}
+        contentContainerStyle={styles.container}
+      >
+        <View style={styles.header}>
+          <ThemedText style={styles.title}>Workout Calendar</ThemedText>
+          <IconButton
+            icon="close"
+            size={20}
+            iconColor={Colors.dark.subText}
+            style={styles.closeButton}
+            onPress={onDismiss}
+          />
+        </View>
+        <Divider style={styles.divider} />
+        <Calendar
+          markedDates={markedDates}
+          onDayPress={(day: DateData) => onDayPress(day.dateString)}
+          theme={calendarTheme}
+          markingType="dot"
+        />
+        <Divider style={styles.divider} />
+        <ScrollView
+          style={styles.listContainer}
+          showsVerticalScrollIndicator={false}
+          nestedScrollEnabled
+        >
+          {formattedHeading && (
+            <ThemedText style={styles.dateHeading}>
+              {formattedHeading}
+            </ThemedText>
+          )}
+          {workoutsForSelectedDate.length === 0 ? (
+            <ThemedText style={styles.emptyText}>
+              {selectedDate
+                ? "No workouts on this day."
+                : "Select a day to see workouts."}
+            </ThemedText>
+          ) : (
+            workoutsForSelectedDate.map((workout) => (
+              <WorkoutHistoryCard
+                key={workout.id}
+                workout={workout}
+                excludeWarmup={excludeWarmup}
+                onPress={(id) => {
+                  onDismiss();
+                  onWorkoutPress(id);
+                }}
+                containerStyle={styles.verticalCard}
+                cardStyle={styles.verticalCardInner}
+              />
+            ))
+          )}
+        </ScrollView>
+      </Modal>
+    </Portal>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.dark.cardBackground,
+    borderRadius: 16,
+    margin: 16,
+    maxHeight: "82%",
+    padding: 16,
+    overflow: "hidden",
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: "bold",
+  },
+  closeButton: {
+    margin: 0,
+  },
+  divider: {
+    marginVertical: 8,
+  },
+  listContainer: {
+    flexGrow: 0,
+  },
+  dateHeading: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: Colors.dark.subText,
+    marginBottom: 8,
+  },
+  emptyText: {
+    color: Colors.dark.subText,
+    marginTop: 4,
+  },
+  verticalCard: {
+    marginRight: 0,
+    marginBottom: 8,
+    width: "100%",
+  },
+  verticalCardInner: {
+    width: "100%",
+  },
+});

--- a/components/stats/WorkoutCalendarModal.tsx
+++ b/components/stats/WorkoutCalendarModal.tsx
@@ -54,6 +54,7 @@ export const WorkoutCalendarModal: React.FC<WorkoutCalendarModalProps> = ({
         visible={visible}
         onDismiss={onDismiss}
         contentContainerStyle={styles.container}
+        theme={{ colors: { backdrop: "rgba(0, 0, 0, 0.65)" } }}
       >
         <View style={styles.header}>
           <ThemedText style={styles.title}>Workout Calendar</ThemedText>
@@ -95,12 +96,11 @@ export const WorkoutCalendarModal: React.FC<WorkoutCalendarModalProps> = ({
                 key={workout.id}
                 workout={workout}
                 excludeWarmup={excludeWarmup}
+                variant="vertical"
                 onPress={(id) => {
                   onDismiss();
                   onWorkoutPress(id);
                 }}
-                containerStyle={styles.verticalCard}
-                cardStyle={styles.verticalCardInner}
               />
             ))
           )}
@@ -113,7 +113,7 @@ export const WorkoutCalendarModal: React.FC<WorkoutCalendarModalProps> = ({
 const styles = StyleSheet.create({
   container: {
     backgroundColor: Colors.dark.cardBackground,
-    borderRadius: 16,
+    borderRadius: 8,
     margin: 16,
     maxHeight: "82%",
     padding: 16,
@@ -146,13 +146,5 @@ const styles = StyleSheet.create({
   emptyText: {
     color: Colors.dark.subText,
     marginTop: 4,
-  },
-  verticalCard: {
-    marginRight: 0,
-    marginBottom: 8,
-    width: "100%",
-  },
-  verticalCardInner: {
-    width: "100%",
   },
 });

--- a/components/stats/WorkoutCalendarModal.tsx
+++ b/components/stats/WorkoutCalendarModal.tsx
@@ -58,13 +58,19 @@ export const WorkoutCalendarModal: React.FC<WorkoutCalendarModalProps> = ({
     : null;
 
   const [calendarReady, setCalendarReady] = useState(false);
+  const [calendarCurrentDate, setCalendarCurrentDate] = useState(() =>
+    format(new Date(), "yyyy-MM-dd"),
+  );
 
   useLayoutEffect(() => {
     if (!visible) return;
+    const targetDate = selectedDate ?? format(new Date(), "yyyy-MM-dd");
+    currentMonthRef.current = targetDate;
+    setCalendarCurrentDate(targetDate);
     setCalendarReady(false);
     const timer = setTimeout(() => setCalendarReady(true), 300);
     return () => clearTimeout(timer);
-  }, [visible]);
+  }, [visible, selectedDate]);
 
   const currentMonthRef = useRef(format(new Date(), "yyyy-MM-dd"));
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -115,6 +121,7 @@ export const WorkoutCalendarModal: React.FC<WorkoutCalendarModalProps> = ({
         <View style={styles.calendarContainer}>
           <CalendarList
             ref={calendarRef}
+            current={calendarCurrentDate}
             markedDates={markedDates}
             onDayPress={(day: DateData) => onDayPress(day.dateString)}
             theme={calendarTheme}

--- a/components/stats/WorkoutCalendarModal.tsx
+++ b/components/stats/WorkoutCalendarModal.tsx
@@ -1,8 +1,14 @@
-import React from "react";
-import { ScrollView, StyleSheet, View } from "react-native";
+import React, { useCallback, useLayoutEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Dimensions,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
 import { Modal, Portal, Divider, IconButton } from "react-native-paper";
-import { Calendar, DateData } from "react-native-calendars";
-import { format, parseISO } from "date-fns";
+import { CalendarList, DateData } from "react-native-calendars";
+import { addMonths, format, parseISO, subMonths } from "date-fns";
 import { ThemedText } from "@/components/ThemedText";
 import WorkoutHistoryCard from "@/components/WorkoutHistoryCard";
 import { CompletedWorkout } from "@/hooks/useCompletedWorkoutsQuery";
@@ -17,7 +23,11 @@ interface WorkoutCalendarModalProps {
   workoutsForSelectedDate: CompletedWorkout[];
   onWorkoutPress: (id: number) => void;
   excludeWarmup?: boolean;
+  loading?: boolean;
 }
+
+// 16px modal margin + 16px padding on each side = 64px total
+const CALENDAR_WIDTH = Dimensions.get("window").width - 64;
 
 const calendarTheme = {
   backgroundColor: Colors.dark.cardBackground,
@@ -26,8 +36,6 @@ const calendarTheme = {
   todayTextColor: Colors.dark.tint,
   selectedDayBackgroundColor: Colors.dark.tint,
   selectedDayTextColor: Colors.dark.background,
-  dotColor: Colors.dark.tint,
-  selectedDotColor: Colors.dark.background,
   monthTextColor: Colors.dark.text,
   arrowColor: Colors.dark.tint,
   textDisabledColor: Colors.dark.subText,
@@ -43,10 +51,44 @@ export const WorkoutCalendarModal: React.FC<WorkoutCalendarModalProps> = ({
   workoutsForSelectedDate,
   onWorkoutPress,
   excludeWarmup = false,
+  loading = false,
 }) => {
   const formattedHeading = selectedDate
     ? format(parseISO(selectedDate), "EEEE, d MMMM")
     : null;
+
+  const [calendarReady, setCalendarReady] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!visible) return;
+    setCalendarReady(false);
+    const timer = setTimeout(() => setCalendarReady(true), 300);
+    return () => clearTimeout(timer);
+  }, [visible]);
+
+  const currentMonthRef = useRef(format(new Date(), "yyyy-MM-dd"));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const calendarRef = useRef<any>(null);
+
+  const navigateMonth = useCallback((dir: "next" | "prev") => {
+    const next = format(
+      dir === "next"
+        ? addMonths(parseISO(currentMonthRef.current), 1)
+        : subMonths(parseISO(currentMonthRef.current), 1),
+      "yyyy-MM-dd",
+    );
+    currentMonthRef.current = next;
+    calendarRef.current?.scrollToMonth(next);
+  }, []);
+
+  const handleVisibleMonthsChange = useCallback((months: DateData[]) => {
+    if (months[0]) {
+      currentMonthRef.current = months[0].dateString;
+      setCalendarReady(true);
+    }
+  }, []);
+
+  const showSpinner = loading || !calendarReady;
 
   return (
     <Portal>
@@ -67,44 +109,69 @@ export const WorkoutCalendarModal: React.FC<WorkoutCalendarModalProps> = ({
           />
         </View>
         <Divider style={styles.divider} />
-        <Calendar
-          markedDates={markedDates}
-          onDayPress={(day: DateData) => onDayPress(day.dateString)}
-          theme={calendarTheme}
-          markingType="dot"
-        />
-        <Divider style={styles.divider} />
-        <ScrollView
-          style={styles.listContainer}
-          showsVerticalScrollIndicator={false}
-          nestedScrollEnabled
-        >
-          {formattedHeading && (
-            <ThemedText style={styles.dateHeading}>
-              {formattedHeading}
-            </ThemedText>
+
+        {/* CalendarList always renders at full height so onVisibleMonthsChange fires.
+            Opaque overlay sits on top while the list is initialising. */}
+        <View style={styles.calendarContainer}>
+          <CalendarList
+            ref={calendarRef}
+            markedDates={markedDates}
+            onDayPress={(day: DateData) => onDayPress(day.dateString)}
+            theme={calendarTheme}
+            markingType="custom"
+            horizontal
+            pagingEnabled
+            firstDay={1}
+            calendarWidth={CALENDAR_WIDTH}
+            showScrollIndicator={false}
+            hideArrows={false}
+            onVisibleMonthsChange={handleVisibleMonthsChange}
+            onPressArrowLeft={() => navigateMonth("prev")}
+            onPressArrowRight={() => navigateMonth("next")}
+          />
+          {showSpinner && (
+            <View style={styles.calendarOverlay}>
+              <ActivityIndicator size="large" color={Colors.dark.tint} />
+            </View>
           )}
-          {workoutsForSelectedDate.length === 0 ? (
-            <ThemedText style={styles.emptyText}>
-              {selectedDate
-                ? "No workouts on this day."
-                : "Select a day to see workouts."}
-            </ThemedText>
-          ) : (
-            workoutsForSelectedDate.map((workout) => (
-              <WorkoutHistoryCard
-                key={workout.id}
-                workout={workout}
-                excludeWarmup={excludeWarmup}
-                variant="vertical"
-                onPress={(id) => {
-                  onDismiss();
-                  onWorkoutPress(id);
-                }}
-              />
-            ))
-          )}
-        </ScrollView>
+        </View>
+
+        {calendarReady && !loading && (
+          <>
+            <Divider style={styles.divider} />
+            <ScrollView
+              style={styles.listContainer}
+              showsVerticalScrollIndicator={false}
+              nestedScrollEnabled
+            >
+              {formattedHeading && (
+                <ThemedText style={styles.dateHeading}>
+                  {formattedHeading}
+                </ThemedText>
+              )}
+              {workoutsForSelectedDate.length === 0 ? (
+                <ThemedText style={styles.emptyText}>
+                  {selectedDate
+                    ? "No workouts on this day."
+                    : "Select a day to see workouts."}
+                </ThemedText>
+              ) : (
+                workoutsForSelectedDate.map((workout) => (
+                  <WorkoutHistoryCard
+                    key={workout.id}
+                    workout={workout}
+                    excludeWarmup={excludeWarmup}
+                    variant="vertical"
+                    onPress={(id) => {
+                      onDismiss();
+                      onWorkoutPress(id);
+                    }}
+                  />
+                ))
+              )}
+            </ScrollView>
+          </>
+        )}
       </Modal>
     </Portal>
   );
@@ -133,6 +200,15 @@ const styles = StyleSheet.create({
   },
   divider: {
     marginVertical: 8,
+  },
+  calendarContainer: {
+    position: "relative",
+  },
+  calendarOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: Colors.dark.cardBackground,
+    alignItems: "center",
+    justifyContent: "center",
   },
   listContainer: {
     flexGrow: 0,

--- a/components/stats/WorkoutCalendarModal.tsx
+++ b/components/stats/WorkoutCalendarModal.tsx
@@ -68,19 +68,17 @@ export const WorkoutCalendarModal: React.FC<WorkoutCalendarModalProps> = ({
 
   useLayoutEffect(() => {
     if (!visible) return;
-    const targetDate = selectedDate ?? format(new Date(), "yyyy-MM-dd");
-    currentMonthRef.current = targetDate;
-    setCalendarCurrentDate(targetDate);
     setCalendarReady(false);
     const timer = setTimeout(() => setCalendarReady(true), 300);
     return () => clearTimeout(timer);
-  }, [visible]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [visible]);
 
   useLayoutEffect(() => {
-    if (!visible || !selectedDate) return;
-    currentMonthRef.current = selectedDate;
-    setCalendarCurrentDate(selectedDate);
-  }, [selectedDate]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (!visible) return;
+    const targetDate = selectedDate ?? format(new Date(), "yyyy-MM-dd");
+    currentMonthRef.current = targetDate;
+    setCalendarCurrentDate(targetDate);
+  }, [visible, selectedDate]);
 
   const navigateMonth = useCallback((dir: "next" | "prev") => {
     const next = format(

--- a/components/stats/WorkoutCalendarModal.tsx
+++ b/components/stats/WorkoutCalendarModal.tsx
@@ -62,6 +62,10 @@ export const WorkoutCalendarModal: React.FC<WorkoutCalendarModalProps> = ({
     format(new Date(), "yyyy-MM-dd"),
   );
 
+  const currentMonthRef = useRef(format(new Date(), "yyyy-MM-dd"));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const calendarRef = useRef<any>(null);
+
   useLayoutEffect(() => {
     if (!visible) return;
     const targetDate = selectedDate ?? format(new Date(), "yyyy-MM-dd");
@@ -77,10 +81,6 @@ export const WorkoutCalendarModal: React.FC<WorkoutCalendarModalProps> = ({
     currentMonthRef.current = selectedDate;
     setCalendarCurrentDate(selectedDate);
   }, [selectedDate]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const currentMonthRef = useRef(format(new Date(), "yyyy-MM-dd"));
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const calendarRef = useRef<any>(null);
 
   const navigateMonth = useCallback((dir: "next" | "prev") => {
     const next = format(

--- a/components/stats/WorkoutCalendarModal.tsx
+++ b/components/stats/WorkoutCalendarModal.tsx
@@ -70,7 +70,13 @@ export const WorkoutCalendarModal: React.FC<WorkoutCalendarModalProps> = ({
     setCalendarReady(false);
     const timer = setTimeout(() => setCalendarReady(true), 300);
     return () => clearTimeout(timer);
-  }, [visible, selectedDate]);
+  }, [visible]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useLayoutEffect(() => {
+    if (!visible || !selectedDate) return;
+    currentMonthRef.current = selectedDate;
+    setCalendarCurrentDate(selectedDate);
+  }, [selectedDate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const currentMonthRef = useRef(format(new Date(), "yyyy-MM-dd"));
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/constants/HelpData.ts
+++ b/constants/HelpData.ts
@@ -94,7 +94,7 @@ export const HELP_DATA: GroupData[] = [
       {
         icon: "stats-chart-outline",
         title: "Stats & History",
-        body: "The Stats tab shows total workouts, total volume, total time, and average session duration over a selectable time range, with a period-over-period delta for each metric. Charts display weekly volume and your training split by body part. Browse your full workout history and tap any session to review every set in detail, including weights, reps, time, or distance. You can edit or delete completed workouts from the history details screen.",
+        body: "The Stats tab shows total workouts, total volume, total time, and average session duration over a selectable time range, with a period-over-period delta for each metric. Charts display weekly volume and your training split by body part. Browse your full workout history and tap any session to review every set in detail, including weights, reps, time, or distance. You can edit or delete completed workouts from the history details screen. Tap the calendar icon in the Workout History section to open a calendar view: days with workouts are highlighted with a yellow circle, and tapping any day shows the workouts logged on that date.",
       },
       {
         icon: "trending-up-outline",

--- a/constants/WhatsNew.ts
+++ b/constants/WhatsNew.ts
@@ -220,6 +220,14 @@ Warm-up sets are visually grouped and styled separately from working sets, and "
 Five new ready-to-use plans are now available: 5-Day Bro Split, 5-Day Push/Pull/Legs, 6-Day Split, Bodyweight, and Dumbbell Only. Whether you're training at home or in the gym, there's a plan to get you started straight away.
 `,
   },
+  {
+    version: 2627,
+    message: `
+📅 New: Workout Calendar!
+
+Tap the calendar icon in the Workout History section on the Stats tab to browse your training history by date. Days with workouts are highlighted, and tapping any day shows the sessions logged on that date.
+`,
+  },
 ];
 
 // Derived from WHATS_NEW_ENTRIES to avoid drift between the constant and entries


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar-based workout history in Stats with a modal to browse days and open workouts

* **Style & UI**
  * Darker modal backdrops across the app for improved contrast
  * Redesigned workout history cards with horizontal/vertical layouts, chip-style metrics and improved date formatting

* **Documentation**
  * Help text updated to describe the calendar icon and viewing workouts by day
  * What's New entry updated to highlight the Workout Calendar

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/isotronic/MuscleQuest/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->